### PR TITLE
option to only do duo auth if the user's ip is different from the last

### DIFF
--- a/login_duo/Makefile.am
+++ b/login_duo/Makefile.am
@@ -19,6 +19,7 @@ install-exec-hook:
 	else \
 	  echo "Found existing ${DESTDIR}$(sysconfdir)/login_duo.conf - updating permissions"; \
 	fi
+	-chown $(DUO_PRIVSEP_USER) $(DESTDIR)$(sysconfdir)
 	-chown $(DUO_PRIVSEP_USER) $(DESTDIR)$(sysconfdir)/login_duo.conf
 	-chmod 600 $(DESTDIR)$(sysconfdir)/login_duo.conf
 

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -176,7 +176,7 @@ do_auth(struct login_ctx *ctx, const char *cmd)
 	duo_t *duo;
 	duo_code_t code;
 	const char *config, *p, *user;
-	char *ip, ipfpname[MAXPATHLEN], buf[32], lastip[32];
+	char *ip, ipfpname[MAXPATHLEN], buf[39], lastip[39];
 	FILE *ipfp;
 	struct stat st;
 	int i, flags, ret, tries;

--- a/login_duo/login_duo.conf
+++ b/login_duo/login_duo.conf
@@ -8,3 +8,5 @@ skey =
 host = 
 ; Send command for Duo Push authentication
 ;pushinfo = yes
+; Only require authentication when logging in from an IP different from the last
+;onlynewip = yes


### PR DESCRIPTION
i have to login to my remote servers many times a day, but pretty much all of my connections are from my office.  having to do the duo authentication every few minutes is not practical, so i added a "onlynewip" option that, when enabled, will write a user's ip to /etc/duo/ip/username and only do duo auth when the ip is different (and then write that new ip to the file).  this way i will only have to do the duo auth if i'm connecting from a remote location (and then once again when i'm back at the office).