### PR TITLE
Issue #28: Initialize supplemental group list when dropping privileges.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,7 +173,7 @@ AC_MSG_NOTICE([Using libdir "$libdir"])
 
 # Check for functions
 AC_CONFIG_LIBOBJ_DIR([compat])
-AC_CHECK_FUNCS([memcpy memset sysconf])
+AC_CHECK_FUNCS([memcpy memset sysconf initgroups])
 AC_REPLACE_FUNCS([asprintf getgrouplist strlcpy vsyslog])
 AC_SEARCH_LIBS(inet_ntoa, nsl)
 AC_SEARCH_LIBS(gethostbyname, resolv nsl)


### PR DESCRIPTION
Changes the calling conventions of drop_privs() in login_duo.c so that initgroups() can be called.