### PR TITLE
Update README to include 'ldconfig' command

### DIFF
--- a/README
+++ b/README
@@ -80,7 +80,9 @@ Then just run "make".
 Install
 -------
 
-"make install" as root should do it.
+"make install" as root should do it. 
+Then run "ldconfig" as root so that your OS finds and loads the 
+new shared library.
 
 login_duo will be installed setuid root by default in order to keep
 the Duo integration and secret keys in your configuration files


### PR DESCRIPTION
You have the “login_duo: error while loading shared libraries” troubleshooting section on https://www.duosecurity.com/docs/duounix-troubleshooting, but I thought you should add this step to the README so that people don't get stuck.
