### PR TITLE
Added SELinux policy module that allows for publickey+pam_duo authentication

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+duo_unix-1.9.14:
+
+- Added SELinux policy module
+
 duo_unix-1.9.13:
 
 - Bugfixes for signal handling

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_PREREQ(2.65)
 
 # Package, version, bug report address
 AC_INIT([duo_unix],
-	[1.9.13],
+	[1.9.14],
 	[support@duosecurity.com])
 
 # Tells autoconf where to find necessary build scripts and macros.

--- a/pam_duo/Makefile.am
+++ b/pam_duo/Makefile.am
@@ -11,6 +11,18 @@ pam_duo_la_LDFLAGS = -module -no-undefined -avoid-version -shared -export-symbol
 
 notrans_dist_man8_MANS = pam_duo.8
 
+semodule_name = authlogin_duo
+semodule:
+	-checkmodule -M -m -o $(semodule_name).mod $(semodule_name).te
+	-semodule_package -o $(semodule_name).pp -m $(semodule_name).mod
+	-semodule -i $(semodule_name).pp
+
+semodule-remove:
+	-semodule -r $(semodule_name)
+	-rm -f $(semodule_name).mod $(semodule_name).pp
+
+.PHONY: semodule semodule-remove
+
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
 	-@if [ ! -f $(DESTDIR)$(sysconfdir)/pam_duo.conf ]; then \

--- a/pam_duo/authlogin_duo.te
+++ b/pam_duo/authlogin_duo.te
@@ -1,0 +1,9 @@
+module authlogin_duo 1.0;
+
+require {
+    type http_port_t;
+    type sshd_t;
+    class tcp_socket name_connect;
+};
+
+allow sshd_t http_port_t:tcp_socket name_connect;


### PR DESCRIPTION
From here I'll document how to setup ssh with OpenSSH v6.2+ to do native public key + pam_duo authentication.
