### PR TITLE
Adding configuration keyword ip_whitelist, this can list IP addresses fo...

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -10,6 +10,7 @@
 
 #define MAX_GROUPS 256
 #define MAX_PROMPTS 3
+#define MAX_IP_WHITELIST 256
 
 #include <pwd.h>
 #include <syslog.h>
@@ -29,6 +30,8 @@ struct duo_config {
     char *cafile;
     char *http_proxy;
     char *groups[MAX_GROUPS];
+    char *ip_whitelist[MAX_IP_WHITELIST];
+    int  ip_whitelist_cnt;
     int  groups_cnt;
     int  groups_mode;
     int  failmode;  /* Duo failure handling: DUO_FAIL_* */
@@ -50,6 +53,8 @@ int duo_common_ini_handler(struct duo_config *cfg, const char *section,
     const char *name, const char*val);
 
 int duo_check_groups(struct passwd *pw, char **groups, int groups_cnt);
+
+int duo_check_ip_whitelist(const char *host, char **ip_whitelist, int ip_whitelist_cnt);
 
 void duo_log(int priority, const char*msg, const char *user, const char *ip,
              const char *err);

--- a/login_duo/login_duo.8
+++ b/login_duo/login_duo.8
@@ -99,6 +99,8 @@ If unable to determine the authentication users's IP address, fallback on the
 IP address of the server. Default is "no".
 .It Cm https_timeout
 Set to the number of seconds to wait for HTTPS responses from Duo Security. If Duo Security takes longer than the configured number of seconds to respond to the preauth API call, the configured failmode is triggered. Other network operations such as DNS resolution, TCP connection establishment, and the SSL handshake have their own independent timeout and retry logic. Default is 0, which disables the HTTPS timeout.
+.It Cm ip_whitelist
+A list of space separated IP addresses for which to bypass Duo authentication.
 .El
 .Pp
 An example configuration file:

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -182,6 +182,11 @@ do_auth(struct login_ctx *ctx, const char *cmd)
         }
     }
 
+    /* Check if IP is whitelisted. */
+    if (duo_check_ip_whitelist(host, cfg.ip_whitelist, cfg.ip_whitelist_cnt) == 1) {
+        return (EXIT_SUCCESS);
+    }
+
     /* Honor configured http_proxy */
     if (cfg.http_proxy != NULL) {
         setenv("http_proxy", cfg.http_proxy, 1);


### PR DESCRIPTION
...r which Duo authentication will be bypassed. When combined with logon script which would add whitelisted IP on first session, + cronjob which would remove whitelisted IPs when no more active sessions, this makes using Ansible on Duo enabled hosts easier.