### PR TITLE
add support for a file which maps from system usernames to duo usernames

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -151,7 +151,7 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
             if (newline != NULL) {
                 *newline = '\0';
             }
-            strncpy(map_cell->to, line + space_offset + 1, USER_MAP_MAX - space_offset - 1);
+            strncpy(map_cell->to, space + 1, USER_MAP_MAX - space_offset - 1);
             // The above will include the trailing NUL from fgets(3)
             if (cfg->user_map == NULL) {
                 cfg->user_map = map_cell;
@@ -178,17 +178,22 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
 void
 duo_config_release(struct duo_config *cfg)
 {
-    struct user_map *map = cfg->user_map;
+    struct user_map *next_map = cfg->user_map;
+    struct user_map *this_map = NULL;
     int i;
 
-    while (map != NULL) {
-        map = map->next;
-        free(map);
+    while (next_map != NULL) {
+        this_map = next_map;
+        next_map = this_map->next;
+        free(this_map);
     }
+    cfg->user_map = NULL;
 
     for (i = 0; i < cfg->groups_cnt; ++i) {
         free(cfg->groups[i]);
+        cfg->groups[i] = NULL;
     }
+    cfg->groups_cnt = 0;
 }
 
 /* map a user using the user_map_file. Returns the original user if no

--- a/lib/util.c
+++ b/lib/util.c
@@ -178,15 +178,17 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
 void
 duo_config_release(struct duo_config *cfg)
 {
-	struct user_map *map = cfg->user_map;
-	while (map != NULL) {
-		map = map->next;
-		free(map);
-	}
+    struct user_map *map = cfg->user_map;
+    int i;
 
-	for (int i = 0; i < cfg->groups_cnt; ++i) {
-		free(cfg->groups[i]);
-	}
+    while (map != NULL) {
+        map = map->next;
+        free(map);
+    }
+
+    for (i = 0; i < cfg->groups_cnt; ++i) {
+        free(cfg->groups[i]);
+    }
 }
 
 /* map a user using the user_map_file. Returns the original user if no

--- a/lib/util.c
+++ b/lib/util.c
@@ -139,6 +139,10 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
                 return (0);
             }
             struct user_map *map_cell = malloc(sizeof(struct user_map));
+            if (map_cell == NULL) {
+                fprintf(stderr, "Out of memory parsing user map file\n");
+                return (0);
+            }
             map_cell->next = NULL;
             size_t space_offset = space - line;
             strncpy(map_cell->from, line, space_offset);
@@ -163,6 +167,26 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
         return (0);
     }
     return (1);
+}
+
+
+/* Release all dynamic memory associated with a config. Does not free the
+ * config struct itself (which, of course, might be on the stack). If the
+ * config was allocated on the heap, freeing that remains the caller's
+ * responsibility.
+ */
+void
+duo_config_release(struct duo_config *cfg)
+{
+	struct user_map *map = cfg->user_map;
+	while (map != NULL) {
+		map = map->next;
+		free(map);
+	}
+
+	for (int i = 0; i < cfg->groups_cnt; ++i) {
+		free(cfg->groups[i]);
+	}
 }
 
 /* map a user using the user_map_file. Returns the original user if no

--- a/lib/util.c
+++ b/lib/util.c
@@ -131,7 +131,7 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
         char line[USER_MAP_MAX];
         int i = 0;
         struct user_map* last = NULL;
-        while (fgets(line, USER_MAP_MAX - 1, f) != NULL) {
+        while (fgets(line, USER_MAP_MAX, f) != NULL) {
             ++i;
             char *space = strchr(line, ' ');
             if (space == NULL) {

--- a/lib/util.c
+++ b/lib/util.c
@@ -152,7 +152,7 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
                 *newline = '\0';
             }
             strncpy(map_cell->to, line + space_offset + 1, USER_MAP_MAX - space_offset - 1);
-            // The above will include the trailing NULK from fgets(3)
+            // The above will include the trailing NUL from fgets(3)
             if (cfg->user_map == NULL) {
                 cfg->user_map = map_cell;
             }

--- a/lib/util.h
+++ b/lib/util.h
@@ -53,6 +53,8 @@ struct duo_config {
 
 void duo_config_default(struct duo_config *cfg);
 
+void duo_config_release(struct duo_config *cfg);
+
 int duo_set_boolean_option(const char *val);
 
 int duo_common_ini_handler(struct duo_config *cfg, const char *section, 

--- a/lib/util.h
+++ b/lib/util.h
@@ -10,6 +10,8 @@
 
 #define MAX_GROUPS 256
 #define MAX_PROMPTS 3
+/* maximum number of bytes in a user map line */
+#define USER_MAP_MAX 1024
 
 #include <pwd.h>
 #include <syslog.h>
@@ -20,6 +22,12 @@ extern int duo_debug;
 enum {
     DUO_FAIL_SAFE = 0,
     DUO_FAIL_SECURE
+};
+
+struct user_map {
+    char from[USER_MAP_MAX];
+    char to[USER_MAP_MAX];
+    struct user_map *next;
 };
 
 struct duo_config {
@@ -40,6 +48,7 @@ struct duo_config {
     int  accept_env;
     int  local_ip_fallback;
     int  https_timeout;
+    struct user_map *user_map;
 };
 
 void duo_config_default(struct duo_config *cfg);
@@ -48,6 +57,8 @@ int duo_set_boolean_option(const char *val);
 
 int duo_common_ini_handler(struct duo_config *cfg, const char *section, 
     const char *name, const char*val);
+
+const char* duo_map_user(const char *user, const struct user_map *user_map);
 
 int duo_check_groups(struct passwd *pw, char **groups, int groups_cnt);
 

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -164,8 +164,10 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     /* Check group membership. */
     matched = duo_check_groups(pw, cfg.groups, cfg.groups_cnt);
     if (matched == -1) {
+        duo_config_release(&cfg);
         return (EXIT_FAILURE);
     } else if (matched == 0) {
+        duo_config_release(&cfg);
         return (EXIT_SUCCESS);
     }
 
@@ -194,6 +196,7 @@ do_auth(struct login_ctx *ctx, const char *cmd)
                     cfg.https_timeout)) == NULL) {
         duo_log(LOG_ERR, "Couldn't open Duo API handle",
             pw->pw_name, host, NULL);
+        duo_config_release(&cfg);
         return (EXIT_FAILURE);
     }
 
@@ -264,6 +267,7 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     }
     duo_close(duo);
 
+    duo_config_release(&cfg);
     return (ret);
 }
 

--- a/pam_duo/pam_duo.8
+++ b/pam_duo/pam_duo.8
@@ -63,6 +63,11 @@ Default is 3.
 .It Cm fallback_local_ip
 If unable to detect the authorizing user's IP address, fallback on the server's
 IP. Default is "no".
+.It Cm user_map_file
+A path to a file which contains mappings from system usernames to Duo usernames.
+Each line of the file should contain a single space-separated mapping pair, with
+the system username before a literal space (ASCII 20) and the duo username after it.
+This doesn't support wide characters at all.
 .El
 .Pp
 An example configuration file:

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -151,7 +151,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 	} else if (!cfg.apihost || !cfg.apihost[0] ||
             !cfg.skey || !cfg.skey[0] || !cfg.ikey || !cfg.ikey[0]) {
 		duo_syslog(LOG_ERR, "Missing host, ikey, or skey in %s", config);
-		return_val (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+		return_val = (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
 		duo_config_release(&cfg);
 		return return_val;
 	}

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -113,6 +113,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 	duopam_const char *config, *cmd, *p, *service, *user;
 	const char *ip, *host;
 	int i, flags, pam_err, matched;
+	int return_val;
 
 	duo_config_default(&cfg);
 
@@ -133,23 +134,32 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 	if (i == -2) {
 		duo_syslog(LOG_ERR, "%s must be readable only by user 'root'",
 		    config);
-		return (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+		return_val = (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+		duo_config_release(&cfg);
+		return return_val;
 	} else if (i == -1) {
 		duo_syslog(LOG_ERR, "Couldn't open %s: %s",
 		    config, strerror(errno));
-		return (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+		return_val = (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+		duo_config_release(&cfg);
+		return return_val;
 	} else if (i > 0) {
 		duo_syslog(LOG_ERR, "Parse error in %s, line %d", config, i);
-		return (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+		return_val = (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+		duo_config_release(&cfg);
+		return return_val;
 	} else if (!cfg.apihost || !cfg.apihost[0] ||
             !cfg.skey || !cfg.skey[0] || !cfg.ikey || !cfg.ikey[0]) {
 		duo_syslog(LOG_ERR, "Missing host, ikey, or skey in %s", config);
-		return (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+		return_val (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+		duo_config_release(&cfg);
+		return return_val;
 	}
         
     /* Check user */
     if (pam_get_user(pamh, &user, NULL) != PAM_SUCCESS ||
         (pw = getpwnam(user)) == NULL) {
+            duo_config_release(&cfg);
             return (PAM_USER_UNKNOWN);
     }
     /* XXX - Service-specific behavior */
@@ -157,6 +167,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
     cmd = NULL;
 	if (pam_get_item(pamh, PAM_SERVICE, (duopam_const void **)
 		(duopam_const void *)&service) != PAM_SUCCESS) {
+                duo_config_release(&cfg);
                 return (PAM_SERVICE_ERR);
         }
     if (strcmp(service, "sshd") == 0) {
@@ -171,6 +182,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
     } else if (strcmp(service, "su") == 0) {
             /* Check calling user for Duo auth, just like sudo */
             if ((pw = getpwuid(getuid())) == NULL) {
+                    duo_config_release(&cfg);
                     return (PAM_USER_UNKNOWN);
             }
             user = pw->pw_name;
@@ -178,8 +190,10 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 	/* Check group membership */
     matched = duo_check_groups(pw, cfg.groups, cfg.groups_cnt);
     if (matched == -1) {
+        duo_config_release(&cfg);
         return (PAM_SERVICE_ERR);
     } else if (matched == 0) {
+        duo_config_release(&cfg);
         return (PAM_SUCCESS);
     }
 
@@ -209,6 +223,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
                     "pam_duo/" PACKAGE_VERSION,
                     cfg.noverify ? "" : cfg.cafile, DUO_NO_TIMEOUT)) == NULL) {
 		duo_log(LOG_ERR, "Couldn't open Duo API handle", user, host, NULL);
+		duo_config_release(&cfg);
 		return (PAM_SERVICE_ERR);
 	}
 	duo_set_conv_funcs(duo, __duo_prompt, __duo_status, pamh);
@@ -263,6 +278,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 	}
 	duo_close(duo);
 	
+	duo_config_release(&cfg);
 	return (pam_err);
 }
 

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -183,6 +183,8 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
         return (PAM_SUCCESS);
     }
 
+    user = duo_map_user(user, cfg.user_map);
+
     /* Grab the remote host */
 	ip = NULL;
 	pam_get_item(pamh, PAM_RHOST,

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -127,6 +127,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 		} else {
 			duo_syslog(LOG_ERR, "Invalid pam_duo option: '%s'",
 			    argv[i]);
+			duo_config_release(&cfg);
 			return (PAM_SERVICE_ERR);
 		}
 	}


### PR DESCRIPTION
Our corporate duo accounts (managed by the IT team) have the "username" set to our fully-qualified email addresses. Rather than getting IT to change all of our Duo accounts, I'm leaning toward just getting our servers to send email addresses in the Duo request.

This diff adds a new parameter for `pam_duo` called `user_map_file`, which should be a path to a file mapping from system usernames to duo usernames. This gets turned into a dinky little linked list which we walk. If we don't find a mapping in that file, we just send the regular unix username to Duo.

CCing @aegarbutt because I talked with him about this.