### PR TITLE
check calling user for Duo auth for su-l PAM service as well as for su

### DIFF
--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -168,7 +168,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
             flags |= DUO_FLAG_SYNC;
     } else if (strcmp(service, "sudo") == 0) {
             cmd = getenv("SUDO_COMMAND");
-    } else if (strcmp(service, "su") == 0) {
+    } else if (strcmp(service, "su") == 0 || strcmp(service, "su-l") == 0) {
             /* Check calling user for Duo auth, just like sudo */
             if ((pw = getpwuid(getuid())) == NULL) {
                     return (PAM_USER_UNKNOWN);


### PR DESCRIPTION
When "su" is called with the "--login" option (or "-" or "-l"), it uses a different PAM service name: "su-l".  pam_duo should check the calling user when this service is run just like it does for the "su" PAM service.