### PR TITLE
Add a config option to pam_duo that sends GECOS instead of username

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -111,6 +111,8 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
             /* Make timeout milliseconds */
             cfg->https_timeout *= 1000;
         }
+    } else if (strcmp(name, "send_gecos") == 0) {
+      cfg->send_gecos = duo_set_boolean_option(val);
     } else {
         /* Couldn't handle the option, maybe it's target specific? */
         return (0);

--- a/lib/util.h
+++ b/lib/util.h
@@ -40,6 +40,7 @@ struct duo_config {
     int  accept_env;
     int  local_ip_fallback;
     int  https_timeout;
+    int  send_gecos;
 };
 
 void duo_config_default(struct duo_config *cfg);

--- a/pam_duo/pam_duo.8
+++ b/pam_duo/pam_duo.8
@@ -63,6 +63,9 @@ Default is 3.
 .It Cm fallback_local_ip
 If unable to detect the authorizing user's IP address, fallback on the server's
 IP. Default is "no".
+.It Cm send_gecos
+Instead of using the unix username, send Duo the contents of the GECOS field
+from /etc/passwd.  Default is "no".
 .El
 .Pp
 An example configuration file:

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -186,8 +186,8 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 
     /* Use GECOS field if called for */
     if (cfg.send_gecos) {
-      if (strlen(pw->gecos) > 0) {
-          user = pw->gecos;
+      if (strlen(pw->pw_gecos) > 0) {
+          user = pw->pw_gecos;
       } else {
           duo_log(LOG_WARNING, "Empty GECOS field", pw->pw_name, host, NULL);
       }

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -184,6 +184,15 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
         return (PAM_IGNORE);
     }
 
+    /* Use GECOS field if called for */
+    if (cfg.send_gecos) {
+      if (strlen(pw->gecos) > 0) {
+          user = pw->gecos;
+      } else {
+          duo_log(LOG_WARNING, "Empty GECOS field", pw->pw_name, host, NULL);
+      }
+    }
+
     /* Grab the remote host */
 	ip = NULL;
 	pam_get_item(pamh, PAM_RHOST,
@@ -207,7 +216,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 	if ((duo = duo_open(cfg.apihost, cfg.ikey, cfg.skey,
                     "pam_duo/" PACKAGE_VERSION,
                     cfg.noverify ? "" : cfg.cafile, DUO_NO_TIMEOUT)) == NULL) {
-		duo_log(LOG_ERR, "Couldn't open Duo API handle", user, host, NULL);
+		duo_log(LOG_ERR, "Couldn't open Duo API handle", pw->pw_name, host, NULL);
 		return (PAM_SERVICE_ERR);
 	}
 	duo_set_conv_funcs(duo, __duo_prompt, __duo_status, pamh);
@@ -223,7 +232,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
                     cfg.pushinfo ? cmd : NULL);
 		if (code == DUO_FAIL) {
 			duo_log(LOG_WARNING, "Failed Duo login",
-			    user, host, duo_geterr(duo));
+			    pw->pw_name, host, duo_geterr(duo));
 			if ((flags & DUO_FLAG_SYNC) == 0) {
 				pam_info(pamh, "%s", "");
                         }
@@ -234,25 +243,25 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 		if (code == DUO_OK) {
 			if ((p = duo_geterr(duo)) != NULL) {
 				duo_log(LOG_WARNING, "Skipped Duo login",
-				    user, host, p);
+				    pw->pw_name, host, p);
 			} else {
 				duo_log(LOG_INFO, "Successful Duo login",
-				    user, host, NULL);
+				    pw->pw_name, host, NULL);
 			}
 			pam_err = PAM_SUCCESS;
 		} else if (code == DUO_ABORT) {
 			duo_log(LOG_WARNING, "Aborted Duo login",
-			    user, host, duo_geterr(duo));
+			    pw->pw_name, host, duo_geterr(duo));
 			pam_err = PAM_ABORT;
 		} else if (cfg.failmode == DUO_FAIL_SAFE &&
                     (code == DUO_CONN_ERROR ||
                      code == DUO_CLIENT_ERROR || code == DUO_SERVER_ERROR)) {
 			duo_log(LOG_WARNING, "Failsafe Duo login",
-			    user, host, duo_geterr(duo));
+			    pw->pw_name, host, duo_geterr(duo));
 			pam_err = PAM_SUCCESS;
 		} else {
 			duo_log(LOG_ERR, "Error in Duo login",
-			    user, host, duo_geterr(duo));
+			    pw->pw_name, host, duo_geterr(duo));
 			pam_err = PAM_SERVICE_ERR;
 		}
 		break;


### PR DESCRIPTION
For whatever reason, it may be that your Duo usernames do not match
your unix usernames, so you might want to tell Duo some other
username.  Put that other username in the GECOS field in /etc/passwd
and turn this on.