### PR TITLE
Support for interactives commands that needs to read from STDIN like MOSH

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -29,6 +29,7 @@ struct duo_config {
     char *cafile;
     char *http_proxy;
     char *groups[MAX_GROUPS];
+    const char **interactives_cmds;
     int  groups_cnt;
     int  groups_mode;
     int  failmode;  /* Duo failure handling: DUO_FAIL_* */
@@ -41,6 +42,7 @@ struct duo_config {
     int  local_ip_fallback;
     int  https_timeout;
     int  send_gecos;
+    int  nb_interactives_cmds;
 };
 
 void duo_config_default(struct duo_config *cfg);

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -136,16 +136,15 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     char buf[64];
     int i, flags, ret, prompts, matched;
     int headless = 0;
+    if ((pw = getpwuid(ctx->uid)) == NULL)
+            die("Who are you?");
 
-        if ((pw = getpwuid(ctx->uid)) == NULL)
-                die("Who are you?");
-        
     duouser = ctx->duouser ? ctx->duouser : pw->pw_name;
     config = ctx->config ? ctx->config : DUO_CONF;
     flags = 0;
-    
+
     duo_config_default(&cfg);
-        
+
     /* Load our private config. */
     if ((i = duo_parse_config(config, __ini_handler, &cfg)) != 0 ||
             (!cfg.apihost || !cfg.apihost[0] || !cfg.skey || !cfg.skey[0] ||


### PR DESCRIPTION
Mosh server needs to read passcode from STDIN in order to be able to use DUO pam integration, this change add support for this, there is also a provision for adding more commands.

The change has been tested for a while on my servers without any issue.
