### PR TITLE
Handle a missing shell from getpwuid

### DIFF
--- a/lib/shell.h
+++ b/lib/shell.h
@@ -1,0 +1,9 @@
+#ifndef SHELL_H
+#define SHELL_H
+
+/* Which shell should we use by default if there's not one provided by getpwuid(3)? */
+#ifndef _DEFAULT_SHELL
+#define _DEFAULT_SHELL "/bin/sh"
+#endif
+
+#endif

--- a/tests/groups-0.t
+++ b/tests/groups-0.t
@@ -51,3 +51,7 @@ admins and not users: skip users
   SKIP
   $ env UID=1004 ./groups.py -d -c confs/mockduo_admins_no_users.conf -f preauth-allow echo SKIP
   SKIP
+
+non-existent shell
+  $ env UID=1005 ./groups.py -d -c confs/mockduo_users.conf -f noshell echo SKIP
+  SKIP

--- a/tests/groups_preload.c
+++ b/tests/groups_preload.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-static struct passwd _passwd[5] = {
+static struct passwd _passwd[6] = {
         { "user1", "*", 1000, 1000, .pw_gecos = "gecos", .pw_dir = "/",
           .pw_shell = "/bin/sh" },
         { "user2", "*", 1001, 100, .pw_gecos = "gecos", .pw_dir = "/",
@@ -22,6 +22,8 @@ static struct passwd _passwd[5] = {
           .pw_shell = "/bin/sh" },
         { "weirdo", "*", 1004, 1004, .pw_gecos = "gecos", .pw_dir = "/",
           .pw_shell = "/bin/sh" },
+        { "noshell", "*", 1005, 1005, .pw_gecos = "gecos", .pw_dir = "/",
+          .pw_shell = NULL },
 };
 
 /* Supplemental groups */


### PR DESCRIPTION
It is legal for the passwd.pw_shell struct element to be NULL. In this
case the behaviour should mirror the default system behaviour and use a
default shell (`/bin/sh` in this case).

This PR adds `lib/shell.h` to contain the default shell. There wasn't any other useful place to stash it, so it gets a new header file.

There are no tests for this since there's a fault with things relating to groups and whatnot:
```lisa@yttrium tests $ ./testpam.py
    ERROR: ld.so: object '/tmp/duo_unix/tests/.libs/libgroups_preload.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.```

If a project member would be willing to give some guidance on writing tests for this I'd be happy to write some.
