### PR TITLE
Add trusted access option to avoid repeated prompts

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -10,6 +10,7 @@
 
 #define MAX_GROUPS 256
 #define MAX_PROMPTS 3
+#define MAX_TA_EXPIRE 1440
 
 #include <pwd.h>
 #include <syslog.h>
@@ -40,6 +41,8 @@ struct duo_config {
     int  accept_env;
     int  local_ip_fallback;
     int  https_timeout;
+    int  ta_expire;
+    char *ta_prefix;
     int  send_gecos;
 };
 
@@ -51,6 +54,13 @@ int duo_common_ini_handler(struct duo_config *cfg, const char *section,
     const char *name, const char*val);
 
 int duo_check_groups(struct passwd *pw, char **groups, int groups_cnt);
+
+int duo_check_trusted_access(struct passwd *pw, struct duo_config *cfg, const char *ip);
+
+char *
+duo_trusted_access_filename(struct passwd *pw, struct duo_config *cfg, const char *ip);
+
+void duo_touch_trusted_access_file(const char *ta_filename);
 
 void duo_log(int priority, const char*msg, const char *user, const char *ip,
              const char *err);

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -169,7 +169,6 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     } else if (matched == 0) {
         return (EXIT_SUCCESS);
     }
-    
 
     /* Check for remote login host */
     if ((host = ip = getenv("SSH_CONNECTION")) != NULL ||

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -121,7 +121,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 	duopam_const char *ip, *service, *user;
 	const char *cmd, *p, *config, *host;
 
-	int i, flags, pam_err, matched;
+	int i, flags, pam_err, matched, trusted;
 
 	duo_config_default(&cfg);
 
@@ -215,6 +215,19 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 		ip = (cfg.local_ip_fallback ? duo_local_ip() : NULL);
 	}
 
+	/* Check for trusted access configuration */
+	if (cfg.ta_expire > 0) {
+		/* Check for recent login/trusted access */
+		trusted = duo_check_trusted_access(pw, &cfg, host);
+		if (trusted == -1) {
+			return (PAM_SERVICE_ERR);
+		} else if (trusted == 1) {
+                        duo_log(LOG_INFO, "Successful Duo cached access login", 
+                            pw->pw_name, host, NULL);
+			return (PAM_SUCCESS);
+		}
+	} 
+
 	/* Honor configured http_proxy */
 	if (cfg.http_proxy != NULL) {
 		setenv("http_proxy", cfg.http_proxy, 1);
@@ -255,6 +268,11 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 			} else {
 				duo_log(LOG_INFO, "Successful Duo login",
 				    pw->pw_name, host, NULL);
+				if (cfg.ta_expire > 0) {
+				    duo_touch_trusted_access_file(duo_trusted_access_filename(pw, &cfg, host));
+				    duo_log(LOG_INFO, "Duo cached access initiated",
+				        pw->pw_name, host, NULL);
+				}
 			}
 			pam_err = PAM_SUCCESS;
 		} else if (code == DUO_ABORT) {


### PR DESCRIPTION
Added two config options for .conf files to enable trusted (or "cached") access to avoid repeated prompts for users logging in multiple times to the same host from the same client.  Fully functional if not enabled.  

New /etc/duo/login_duo.conf configuration options:

* **taexpire** - the number of minutes for which  trusted access valid.  Maximum of 1440 (24 hours).  Trusted access expiration is rolling, much like sudo.
* **taprefix** - the directory into which login_duo writes session files.  This should be owned by the root user and the sshd group, with mode of 0770.  Files will be written by the ssh daemon with a well-formed file name.

Login will happily continue without trusted access in the case of a file error.