### PR TITLE
Fix 2 rpm build issues

### DIFF
--- a/duo_unix.spec.in
+++ b/duo_unix.spec.in
@@ -67,6 +67,7 @@ make %{?_smp_mflags}
 [ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT
 rm -f $RPM_BUILD_ROOT/%{_lib}/security/pam_duo.*a
+rm -f $RPM_BUILD_ROOT/%{_includedir}/duo/shell.h
 
 %post -n libduo -p /sbin/ldconfig
 

--- a/duo_unix.spec.in
+++ b/duo_unix.spec.in
@@ -103,7 +103,7 @@ rm -f $RPM_BUILD_ROOT/%{_lib}/security/pam_duo.*a
 %{_mandir}/man3/duo.3.gz
 
 %changelog
-* Sun Jul 12 2014 S. Zachariah Sprackett <zac@sprackett.com> 0:1.9.11-0
+* Sat Jul 12 2014 S. Zachariah Sprackett <zac@sprackett.com> 0:1.9.11-0
 - Make things work with modern duo
 
 * Thu Aug 22 2013 Mark Stanislav <mark.stanislav@gmail.com> 0:1.9.3-0
@@ -113,7 +113,7 @@ rm -f $RPM_BUILD_ROOT/%{_lib}/security/pam_duo.*a
 - Add OpenSSH server buildreq for people building in chroots with Mock
 - Fixups to handle documentation being installed by Makefile
 
-* Fri Sep 1 2011 R.I.Pienaar <rip@devco.net> 0:1.8-0
+* Thu Sep 1 2011 R.I.Pienaar <rip@devco.net> 0:1.8-0
 - Fix the ownership of /etc/duo/login_duo.conf so that login as normal users work
 * Tue Aug 23 2011 Mark Stanislav <mark.stanislav@gmail.com> 0:1.7-0
 - Removed README.{pam,ssh} from build related to commit 0d65488ae3cae2e97484


### PR DESCRIPTION
These 2 small fixes enable the duo rpm package to be built on the newer version of rpm included in centos 7.