### PR TITLE
MacOS X supports more than 16 groups

### DIFF
--- a/compat/groupaccess.c
+++ b/compat/groupaccess.c
@@ -57,12 +57,16 @@ ga_init(const char *user, gid_t base)
 	if (ngroups > 0)
 		ga_free();
 
+#ifdef __APPLE__
+	ngroups = 1024;
+#else
 	ngroups = NGROUPS_MAX;
-#if defined(HAVE_SYSCONF) && defined(_SC_NGROUPS_MAX)
-#ifndef MAX
-# define MAX(a,b) (((a)>(b))?(a):(b))
-#endif        
+#  if defined(HAVE_SYSCONF) && defined(_SC_NGROUPS_MAX)
+#    ifndef MAX
+#      define MAX(a,b) (((a)>(b))?(a):(b))
+#    endif
 	ngroups = MAX(NGROUPS_MAX, sysconf(_SC_NGROUPS_MAX));
+#  endif
 #endif
 
 	if (!(groups_bygid = calloc(ngroups, sizeof(*groups_bygid))) ||


### PR DESCRIPTION
I'm not sure why, but macOS sets NGROUP_MAX to 16, even though you can be in more groups than that (at least on our Active Directory bound mac's).  Looking at the code, I don't believe it will harm anything to artificially increase this.  I chose 1024, but I suppose any large number would be good.  :)
