### PR TITLE
lib/https.c: Update hmac handling for LibreSSL

### DIFF
--- a/lib/https.c
+++ b/lib/https.c
@@ -352,8 +352,9 @@ _establish_connection(struct https_request * const req,
 
 /* Provide implementations for HMAC_CTX_new and HMAC_CTX_free when
  * building for OpenSSL versions older than 1.1.0
+ * or any version of LibreSSL.
  */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 static HMAC_CTX *
 HMAC_CTX_new(void)
 {


### PR DESCRIPTION
Extend commit 673b3ce to support libressl.

Resolves build failure on libressl:

    ttps.c: In function 'https_send':
    https.c:687:17: warning: implicit declaration of function 'HMAC_CTX_new' [-Wimplicit-function-declaration]
	 if ((hmac = HMAC_CTX_new()) == NULL) {
		     ^~~~~~~~~~~~
    https.c:687:15: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
	 if ((hmac = HMAC_CTX_new()) == NULL) {
		     ^
    https.c:696:5: warning: implicit declaration of function 'HMAC_CTX_free' [-Wimplicit-function-declaration]
	 HMAC_CTX_free(hmac);
	 ^~~~~~~~~~~~~

    ./.libs/libduo.a(https.o): In function `https_send':
    https.c:(.text+0x66d): undefined reference to `HMAC_CTX_new'
    https.c:(.text+0x70f): undefined reference to `HMAC_CTX_free'
    collect2: error: ld returned 1 exit status

Signed-off-by: Paul Morgan <jumanjiman@gmail.com>