### PR TITLE
Domain feature to authenticate ssh users with email in DUO

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -75,6 +75,8 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
             }
             cfg->groups[cfg->groups_cnt++] = p;
         }
+    } else if (strcmp(name, "domain") == 0) {
+        cfg->domain = strdup(val);
     } else if (strcmp(name, "failmode") == 0) {
         if (strcmp(val, "secure") == 0) {
             cfg->failmode = DUO_FAIL_SECURE;

--- a/lib/util.h
+++ b/lib/util.h
@@ -29,6 +29,7 @@ struct duo_config {
     char *cafile;
     char *http_proxy;
     char *groups[MAX_GROUPS];
+    char *domain;
     int  groups_cnt;
     int  groups_mode;
     int  failmode;  /* Duo failure handling: DUO_FAIL_* */

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -250,8 +250,17 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
     pam_err = PAM_SERVICE_ERR;
 
     for (i = 0; i < cfg.prompts; i++) {
-        code = duo_login(duo, user, host, flags,
-                    cfg.pushinfo ? cmd : NULL);
+        if (!cfg.domain || !cfg.domain[0]) {
+            code = duo_login(duo, user, host, flags,
+                cfg.pushinfo ? cmd : NULL);
+        } else {
+            char *duo_auth_user=(char*)malloc(strlen(user)+strlen(cfg.domain)+2);
+            memset(duo_auth_user,0,strlen(user)+strlen(cfg.domain)+2);
+            strcpy(duo_auth_user,user);
+            code = duo_login(duo, strcat(strcat(duo_auth_user, "@"), cfg.domain), host, flags,
+                cfg.pushinfo ? cmd : NULL);
+        }
+
         if (code == DUO_FAIL) {
             duo_log(LOG_WARNING, "Failed Duo login",
                 pw->pw_name, host, duo_geterr(duo));

--- a/pam_duo/pam_duo.conf
+++ b/pam_duo/pam_duo.conf
@@ -8,3 +8,5 @@ skey =
 host = 
 ; Send command for Duo Push authentication
 ;pushinfo = yes
+; authenticate email instead of username by appending domain
+;domain = 


### PR DESCRIPTION
Adding domain option in pam_duo.conf file

This is to add 'domain' field to pam_duo.conf.
This is the working fix where DUO username is their email id instead of just username.
And when you are trying to configure ssh with DUO authentication, it tries to
register a new 'USER' with DUO even though 'USER@MYCOMPANY.com' is there in DUO.

With this feature, once  'USER' gets authenticated with pam_unix, we are apending
'domain' value to 'USER' and making it 'USER@MYCOMPANY.com' to get authenticated from DUO.

Example pam_duo.conf file:
[duo]
; Duo integration key
ikey = XXXXXXXXXXXXXXXXXX
; Duo secret key
skey = XXXXXXXXXXXXXXXXX
; Duo API host
host = api-XXXXXXXXXXXXXXXXXXXX
; Send command for Duo Push authentication
;pushinfo = yes
; authenticate email instead of username by appending domain
domain = mycompany.com

Now 'abc' user gets authenticated with unix as 'abc' and with DUO as 'abc@mycompany.com'