### PR TITLE
properly return PAM_MAXTRIES if prompts=N set where N != 3

### DIFF
--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -290,7 +290,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
         break;
     }
     if (i == MAX_PROMPTS) {
-        pam_err = PAM_MAXTRIES;
+        pam_err = cfg.prompts;
     }
     duo_close(duo);
 


### PR DESCRIPTION
The auth loop limits at cfg.prompts, but the check at the end of the loop for whether to return PAM_MAXTRIES compares to the constand MAX_PROMPTS instead. This works if prompts=3 in pam_duo.conf, or isn't specified (same effect), but fails if any other value is used, returning PAM_SERVICE_ERR instead.