### PR TITLE
update authlogin_duo SELinux module to permit HTTP proxies

### DIFF
--- a/pam_duo/authlogin_duo.te
+++ b/pam_duo/authlogin_duo.te
@@ -1,9 +1,10 @@
-module authlogin_duo 1.0;
+module authlogin_duo 1.0.1;
 
 require {
     type http_port_t;
+    type http_cache_port_t;
     type sshd_t;
     class tcp_socket name_connect;
 };
 
-allow sshd_t http_port_t:tcp_socket name_connect;
+allow sshd_t {http_port_t http_cache_port_t}:tcp_socket name_connect;


### PR DESCRIPTION
While Duo can be configured to use an HTTP proxy, the authlogin_duo SELinux module only permits outbound connections to TCP ports with the `http_port_t` SELinux label.

This is a problem, because HTTP proxies are typically configured to listen on ports with the `http_cache_port_t` SELinux label. (For example, 8080 is a common port to use for HTTP proxies, and port 8080 has the `http_cache_port_t` SELinux label, not the `http_port_t` label.)

This change updates the authlogin_duo SELinux module to permit the `sshd_t` type to connect to both `http_port_t` and `http_cache_port_t` ports, and increments the module version number.