### PR TITLE
Feature: add remember me to pam_duo

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -14,6 +14,7 @@
 #include <pwd.h>
 #include <syslog.h>
 #include <stdarg.h>
+#include <time.h>
 
 extern int duo_debug;
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -44,7 +44,15 @@ struct duo_config {
     int  send_gecos;
     int  fips_mode;
     int  gecos_username_pos;
+    long int  remember_me_duration; /* in seconds */
+    int  remember_me_protected;
 };
+
+struct remembered {
+    int addr[4];
+    time_t time;
+};
+
 
 void duo_config_default(struct duo_config *cfg);
 
@@ -80,5 +88,26 @@ char *duo_split_at(char *s, char delimiter, unsigned int position);
 
 /* Free and zero out memory */
 void duo_zero_free(void *ptr, size_t size);
+
+/* Remember me */
+
+int duo_is_remembered(
+    struct passwd *pw,
+    const char *fn,
+    struct duo_config *cfg,
+    const char *host
+);
+
+void duo_remember(
+    struct passwd *pw,
+    const char *fn,
+    struct duo_config *cfg,
+    const char *host
+);
+
+char *duo_remember_me_prompt(
+    struct duo_config *cfg,
+    const char *host
+);
 
 #endif

--- a/pam_duo/pam_duo.8
+++ b/pam_duo/pam_duo.8
@@ -66,6 +66,11 @@ IP. Default is "no".
 .It Cm send_gecos
 Instead of using the unix username, send Duo the contents of the GECOS field
 from /etc/passwd.  Default is "no".
+.It Cm remember_me
+Specifies a time period to remember authorizations from connections. The time period is specified with a number followed by one of the following letters:
+D,d,H,h,M,m,S,s where d or D is for days, h or H is for hours, m or M is for minutes and s or S is for seconds. Default is 0S which disables remember me. When remember me is enabled authorized connections will be saved in a ~/.pam_duo_remember file. Subsequent connections will be checked for a matching host in the remember file and if a match is found and if the time since last authentication has not exceeded the remember_me time duo authentication will be skipped.
+.It Cm remember_me_protected
+If set to yes the remember me file, ~/.pam_duo_remember, will be owned by root otherwise it is owned by the user.
 .El
 .Pp
 An example configuration file:
@@ -76,6 +81,8 @@ ikey = SI9F...53RI
 skey = 4MjR...Q2NmRiM2Q1Y
 pushinfo = yes
 autopush = yes
+remember_me = 1D
+remember_me_protected = no
 .Ed
 .Pp
 Other authentication restrictions may be implemented using 

--- a/pam_duo/pam_duo.conf
+++ b/pam_duo/pam_duo.conf
@@ -13,3 +13,7 @@ host =
 failmode = safe
 ; Send command for Duo Push authentication
 ;pushinfo = yes
+; Remember me duration (i.e. 30s for 30 seconds, 45m for 45 minutes, 2h for two hours, 30d for 30 days)
+; remember_me =
+; Remember me file protected. If set to yes ~/.pam_duo_remember will be owned by root otherwise by user
+; remember_me_protected =


### PR DESCRIPTION
This will add a remember me feature to pam_duo. By simply adding
a "remember_me" configuration setting to pam_duo.conf such as:

remember_me = 14D

when a user authenticates with duo from a host the connection
authentication for that host will be remembered for that specified
number of seconds, minutes, hours or days using a value such as
10s or 20m or 12h or 30d to specify durations of 10 seconds or
20 minutes or 12 hours or 30 days.

subsequent connections from that host will not require duo authentication
until the time period expires.

If the remember me feature is enabled and duo confirmation is performed
the user will be prompted to select whether the authentication for that
host should be remembered or not.

The remember me information is stored in a binary file called
~/.pam_duo_remember on the server side of the connection. An optional
remember_me_protected option in pam_duo.conf can be set to yes if it is
desired to have these ~/.pam_duo_remember files to be owned by root instead
of the user account.

## Issue number being addressed
Fixes #

## Summary of the change

## Test Plan

