### PR TITLE
Add strnlen to compat folder for support on older systems

### DIFF
--- a/acconfig.h
+++ b/acconfig.h
@@ -19,3 +19,8 @@ int	getgrouplist(const char *name, gid_t basegid, gid_t *groups, int *ngroups);
 size_t	strlcpy(char *dst, const char *src, size_t size);
 #endif
 
+#ifndef HAVE_STRNLEN
+#include <sys/types.h>
+
+size_t strnlen(const char *str, size_t maxlen);
+#endif

--- a/compat/strnlen.c
+++ b/compat/strnlen.c
@@ -1,0 +1,34 @@
+/*	$OpenBSD: strnlen.c,v 1.9 2019/01/25 00:19:25 millert Exp $	*/
+
+/*
+ * Copyright (c) 2010 Todd C. Miller <millert@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+
+#include <string.h>
+
+size_t
+strnlen(const char *str, size_t maxlen)
+{
+	const char *cp;
+
+	for (cp = str; maxlen != 0 && *cp != '\0'; cp++, maxlen--)
+		;
+
+	return (size_t)(cp - str);
+}
+// XXX DUO MOD. Remove weak symbol declaration as it's not supported on all systems
+// DEF_WEAK(strnlen);

--- a/configure.ac
+++ b/configure.ac
@@ -179,7 +179,7 @@ AC_MSG_NOTICE([Using libdir "$libdir"])
 # Check for functions
 AC_CONFIG_LIBOBJ_DIR([compat])
 AC_CHECK_FUNCS([memcpy memset sysconf getaddrinfo open64 fopen64 explicit_bzero memset_s])
-AC_REPLACE_FUNCS([asprintf getgrouplist strlcpy vsyslog])
+AC_REPLACE_FUNCS([asprintf getgrouplist strlcpy vsyslog strnlen])
 AC_SEARCH_LIBS(inet_ntoa, nsl)
 AC_SEARCH_LIBS(socket, socket)
 


### PR DESCRIPTION
## Issue number being addressed
Issue came from Duo support

## Summary of the change
Took strnlen from https://github.com/libressl-portable/openbsd/blob/master/src/lib/libc/string/strnlen.c
and added it to the compat folder in Duo Unix.
Made one minor modification because we don't have a concept of weak links in our code.

## Test Plan
Tested on a solaris 10 box where the issue was originally discovered
Unit tests also passed on Linux