### PR TITLE
Retry rate limited requests with exponential backoff

### DIFF
--- a/lib/duo.c
+++ b/lib/duo.c
@@ -397,10 +397,7 @@ duo_call(struct duo_ctx *ctx, const char *method, const char *uri, int msecs)
                     ctx->argc, ctx->argv, ctx->ikey, ctx->skey, ctx->useragent)) == HTTPS_OK &&
             (err = https_recv(ctx->https, &code,
                 &ctx->body, &ctx->body_len, msecs)) == HTTPS_OK) {
-            if (code == 429) {
-                /* Retry rate limited requests */
-                continue;
-            } else {
+            if (code != 429) {  /* retry rate limited requests */
                 break;
             }
         }

--- a/tests/login_duo-7.t
+++ b/tests/login_duo-7.t
@@ -10,10 +10,19 @@ Failsafe preauth fail
   [3] Error in Duo login for 'auth_timeout': HTTP 500
   [1]
 
-
 Failsecure preauth fail
   $ ${BUILDDIR}/login_duo/login_duo -d -c confs/mockduo_failsecure.conf -f auth_timeout true
   [3] Error in Duo login for 'auth_timeout': HTTP 500
+  [1]
+
+Failsafe preauth rate limited
+  $ ${BUILDDIR}/login_duo/login_duo -d -c confs/mockduo.conf -f preauth_rate_limited true
+  [4] Aborted Duo login for 'preauth_rate_limited': HTTP 429
+  [1]
+
+Failsecure preauth rate limited
+  $ ${BUILDDIR}/login_duo/login_duo -d -c confs/mockduo_failsecure.conf -f preauth_rate_limited true
+  [4] Aborted Duo login for 'preauth_rate_limited': HTTP 429
   [1]
 
 Failmode safe check

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -176,6 +176,9 @@ class MockDuoHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 ret['response'] = { 'result': 'allow', 'status': 'full-gecos-field' }
             elif self.args['user'] == 'gecos/6':
                 ret['response'] = { 'result': 'allow', 'status': 'gecos/6' }
+            elif self.args['user'] == 'preauth_rate_limited':
+                ret = { 'stat': 'FAIL', 'code': 42901, 'message': 'Too Many Requests' }
+                return self._send(429, bson.dumps(ret))
             else:
                 ret['response'] = {
                     'result': 'auth',

--- a/tests/pam_duo-6.t
+++ b/tests/pam_duo-6.t
@@ -11,12 +11,20 @@ Failsafe preauth fail
   Autopushing login request to phone...
   [1]
 
-
-
 Failsecure preauth fail
   $ ./testpam.py -d -c confs/mockduo_autopush_secure.conf -f auth_timeout true
   [3] Error in Duo login for 'auth_timeout': HTTP 500
   Autopushing login request to phone...
+  [1]
+
+Failsafe preauth rate-limited
+  $ ./testpam.py -d -c confs/mockduo_autopush.conf -f preauth_rate_limited true
+  [4] Aborted Duo login for 'preauth_rate_limited': HTTP 429
+  [1]
+
+Failsecure preauth rate-limited
+  $ ./testpam.py -d -c confs/mockduo_autopush_secure.conf -f preauth_rate_limited true
+  [4] Aborted Duo login for 'preauth_rate_limited': HTTP 429
   [1]
 
 Failmode safe
@@ -24,6 +32,7 @@ Failmode safe
   [4] Aborted Duo login for 'failopen': correct failmode
   correct failmode
   [1]
+
 Failmode secure
   $ ./testpam.py -d -c confs/mockduo_failsecure.conf -f failclosed true
   [4] Aborted Duo login for 'failclosed': correct failmode


### PR DESCRIPTION
## Summary of the change
If the Duo service responds with a 429, retry the request up to twice w/ an exponential backoff. In order to prevent multiple concurrent duo unix authentications from overlapping again on the retry, this also adds a random extra wait time. This is similar to what duo_client_python does (https://github.com/duosecurity/duo_client_python/blob/b24ff1e/duo_client/client.py#L342) except it only retries up to twice because it was more convenient to re-use the existing code that retried on network errors.

## Test Plan
Added two new cram tests for 429s, and manually verified that the retries actually happen. I made the Duo service respond with 429s half of the time, and verified that authentications still succeeded after retrying; when they got unlucky, the logs in syslog look reasonable:
```
Sep 18 18:45:00 foo login_duo[364864]: Successful Duo login for 'marcus'
Sep 18 18:45:08 foo login_duo[364893]: Aborted Duo login for 'marcus': HTTP 429
```