### PR TITLE
Travis-ci: added support for ppc64le along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ os:
 compiler:
     - clang
     - gcc
+arch:
+  - amd64
+  - ppc64le
+matrix:
+   exclude:
+      - os: osx
+        arch: ppc64le
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi


### PR DESCRIPTION
## Issue number being addressed
Fixes #
Supported the ppc64le build on travis-ci.
## Summary of the change
Added arch as 'ppc64le' and 'amd64'(default).
## Test Plan
Full build log cab be tracked here https://travis-ci.com/github/sanjaymsh/duo_unix/builds/187623610.

I believe it is ready for the final review and and merge.
Please have a look on this.

Thanks !!

