### PR TITLE
Added hardening compiler flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libpam-dev; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y automake; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y cppcheck; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libssl-dev; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export OS_SPECIFIC_ARGS=""; fi
 script:
     - ./bootstrap

--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_DEFINE_DIR([UNITY_VERSION], [unity_version], [Unity directory name])
 
 # Compiler options
 if test "x$GCC" = "xyes"; then
-   CFLAGS="$CFLAGS -Wall -D_FORTIFY_SOURCE=2"
+   CFLAGS="$CFLAGS -Wall -D_FORTIFY_SOURCE=2 -Wl,-z,relro,-z,now -fPIE"
    AC_MSG_NOTICE([Adding gcc options: $CFLAGS])
 fi
 GGL_CHECK_STACK_PROTECTOR([has_stack_protector=yes], [has_stack_protector=no])

--- a/configure.ac
+++ b/configure.ac
@@ -46,13 +46,16 @@ AC_DEFINE_DIR([UNITY_VERSION], [unity_version], [Unity directory name])
 
 # Compiler options
 if test "x$GCC" = "xyes"; then
-   CFLAGS="$CFLAGS -Wall -D_FORTIFY_SOURCE=2 -Wl,-z,relro,-z,now,--no-as-needed,-ldl -fPIE"
+   CFLAGS="$CFLAGS -Wall -D_FORTIFY_SOURCE=2 -fPIE"
    AC_MSG_NOTICE([Adding gcc options: $CFLAGS])
 fi
 GGL_CHECK_STACK_PROTECTOR([has_stack_protector=yes], [has_stack_protector=no])
 IS_AIX=no
 # XXX - disable -fstack-protector due to missing libssp_nonshared
 case "$host_os" in
+    linux* | gnu* | k*bsd*-gnu)
+        CFLAGS="$CFLAGS -Wl,-z,relro,-z,now,--no-as-needed,-ldl"
+        ;;
     *aix*)
         AC_MSG_NOTICE([-fstack-protector disabled on AIX])
         has_stack_protector=no

--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_DEFINE_DIR([UNITY_VERSION], [unity_version], [Unity directory name])
 
 # Compiler options
 if test "x$GCC" = "xyes"; then
-   CFLAGS="$CFLAGS -Wall -D_FORTIFY_SOURCE=2 -Wl,-z,relro,-z,now -fPIE"
+   CFLAGS="$CFLAGS -Wall -D_FORTIFY_SOURCE=2 -Wl,-z,relro,-z,now,--no-as-needed,-ldl -fPIE"
    AC_MSG_NOTICE([Adding gcc options: $CFLAGS])
 fi
 GGL_CHECK_STACK_PROTECTOR([has_stack_protector=yes], [has_stack_protector=no])


### PR DESCRIPTION
## Summary of the change
In order to harden Duo Unix against memory corruption and exploitation I've added full RELRO to `pam_duo.so` and `login_duo`

## Test Plan
Before

```
$ ./checksec --file=duo_unix/pam_duo/.libs/pam_duo.so
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH      Symbols         FORTIFY Fortified       Fortifiable     FILE
Partial RELRO   Canary found      NX enabled    DSO             No RPATH   No RUNPATH   358) Symbols      Yes   9               16              duo_unix/pam_duo/.libs/pam_duo.so

$ ./checksec --file=duo_unix/login_duo/login_duo
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH      Symbols         FORTIFY Fortified       Fortifiable     FILE
Partial RELRO   Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   382) Symbols      Yes   9               17              duo/duo_unix/login_duo/login_duo
```

After

```
$ ./checksec --file=duo_unix/pam_duo/.libs/pam_duo.so
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH      Symbols         FORTIFY Fortified       Fortifiable     FILE
Full RELRO      Canary found      NX enabled    DSO             No RPATH   No RUNPATH   357) Symbols      Yes   9               16              duo/duo_unix/pam_duo/.libs/pam_duo.so

$ ./checksec --file=duo_unix/login_duo/login_duo
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH      Symbols         FORTIFY Fortified       Fortifiable     FILE
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   381) Symbols      Yes   9               17              duo/duo_unix/login_duo/login_duo
```