### PR TITLE
Added coverage configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ Example failing test
 $ echo "Hello World"
 Goodbye World
 ```
+### Testing with coverage
+To generate coverate reports you'll need to compile Duo Unix with the `--with-coverage` options.
+Please note that in order to view HTML version of the coverage reports you'll also need to
+install the python package `gcovr`.
+
+To see the testing coverage of the Duo PAM for example you would run the following at the
+repository root.
+```
+$ ./configure --with-coverage --with-pam
+$ ./collect_coverage.sh
+$ $BROWSER coverage/pam_duo.html
+```
+```
+Note that configuring Duo Unix --with-coverage disables any compiler optimizations
+to allow the profiler to better match executed instructions with lines of code.
 
 ### Other testing tips
 

--- a/configure.ac
+++ b/configure.ac
@@ -46,8 +46,10 @@ AC_DEFINE_DIR([UNITY_VERSION], [unity_version], [Unity directory name])
 
 # Compiler options
 if test "x$GCC" = "xyes"; then
-   CFLAGS="$CFLAGS -Wall -D_FORTIFY_SOURCE=2 -fPIE"
-   AC_MSG_NOTICE([Adding gcc options: $CFLAGS])
+   if test "x$with_coverage" != "xyes"; then
+      CFLAGS="$CFLAGS -Wall -D_FORTIFY_SOURCE=2 -fPIE"
+      AC_MSG_NOTICE([Adding gcc options: $CFLAGS])
+   fi
 fi
 GGL_CHECK_STACK_PROTECTOR([has_stack_protector=yes], [has_stack_protector=no])
 IS_AIX=no
@@ -108,6 +110,18 @@ case "$host" in
      *linux*)          PAM_DIR="/lib/security" ;;
      *)                PAM_DIR="/usr/lib/security" ;; # NetBSD, Solaris, AIX, HP-UX
 esac
+
+AC_ARG_WITH(coverage,
+  AS_HELP_STRING([--with-coverage=COV],[build for coverage testing]),
+  [],
+  [ with_coverage=no ]
+)
+AM_CONDITIONAL([COVERAGE], [ test "x$with_coverage" != "xno" ])
+AS_IF([test "x$with_coverage" != "xno"], [
+   CFLAGS="$CFLAGS -O0 --coverage"
+   LFLAGS="$LFLAGS -lgcov --coverage"
+   AC_MSG_NOTICE([--coverage enabled in CFLAGS])
+])
 
 # Check PAM
 AC_ARG_WITH(pam,

--- a/tests/fips_scanner.sh
+++ b/tests/fips_scanner.sh
@@ -127,11 +127,12 @@ echo -e "===================================\n"
 
 #Exclude files that are being used to search for anything not fips compliant 
 #Unless excluded, these files will also be scanned and trigger false positives
+errorFile="fips_scanner.sh.err"
 fipsScanner="fips_scanner.sh"
 testCrypto="test_crypto-0*"
 for cipher in ${CIPHER_LIST[@]} ; do
     echo "Scanning for cipher function: ${cipher}"
-    if grep -R ${cipher} ${DIR} --exclude={$fipsScanner,$testCrypto} ; then
+    if grep -R ${cipher} ${DIR} --exclude={$fipsScanner,$testCrypto,$errorFile} ; then
       echo -e "\e[92mFound potential calls for ${cipher}\e[0m"
     fi
 done
@@ -157,7 +158,7 @@ echo -e "\nChecking for low-level digest calls"
 echo -e "===================================\n"
 for digest in ${DIGEST_LIST[@]} ; do
     echo "Scanning for cipher function: ${digest}"
-    if grep -R ${digest} ${DIR} --exclude={$fipsScanner,$testCrypto} ; then
+    if grep -R ${digest} ${DIR} --exclude={$fipsScanner,$testCrypto,$errorFile} ; then
       echo -e "\e[92mFound potential calls for ${digest}\e[0m"
     fi    
 done

--- a/tests/unity_tests/Makefile.am
+++ b/tests/unity_tests/Makefile.am
@@ -10,7 +10,7 @@ check_PROGRAMS = $(UNITY_TESTS)
 include_HEADERS = common_ini_test.h
 
 LDADD = $(top_builddir)/lib/libduo.la $(top_builddir)/compat/libcompat.la $(top_builddir)/tests/unity_tests/$(UNITY_VERSION)/libunity.la
-CFLAGS = -Werror -Wunused-function
+CFLAGS = @CFLAGS@ -Werror -Wunused-function
 
 if PAM
 UNITY_TESTS += pam_argv_parse_test

--- a/tests/unity_tests/bson_iter_init_test.c
+++ b/tests/unity_tests/bson_iter_init_test.c
@@ -34,7 +34,6 @@ static void test_bson_iter_init_four_size() {
     bson_iterator it;
     /* 4..1 */
     char msg[4] = "\x04\x00\x00\x01";
-    char *expected_error_msg = "Invalid BSON response";
     int msg_size = 4;
     reached_error_test = 0;
 

--- a/tests/unity_tests/common_ini_string_options.c
+++ b/tests/unity_tests/common_ini_string_options.c
@@ -5,8 +5,8 @@ static void test_ikey() {
     struct duo_config cfg = {0};
     char *name = "ikey";
     char *value = "1234123412341234";
-    char *expected_value = "1234123412341234"; 
-    
+    char *expected_value = "1234123412341234";
+
     duo_common_ini_handler(&cfg, SECTION, name, value);
     TEST_ASSERT_EQUAL_STRING(expected_value, cfg.ikey);
 }
@@ -17,7 +17,7 @@ static void test_ikey_empty() {
     const char *expected_value = EMPTY_STR;
 
     duo_common_ini_handler(&cfg, SECTION, name, EMPTY_STR);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.ikey); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.ikey);
 }
 
 static void test_ikey_null() {
@@ -26,7 +26,7 @@ static void test_ikey_null() {
     const char *expected_value = NULL_STR;
 
     duo_common_ini_handler(&cfg, SECTION, name, NULL_STR);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.ikey); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.ikey);
 }
 
 /* Test adding skey to duo_config */
@@ -37,16 +37,16 @@ static void test_skey() {
     char *expected_value = "1234123412341234";
 
     duo_common_ini_handler(&cfg, SECTION, name, value);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.skey); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.skey);
 }
 
 static void test_skey_empty() {
     struct duo_config cfg = {0};
     char *name = "skey";
     const char *expected_value = EMPTY_STR;
-    
+
     duo_common_ini_handler(&cfg, SECTION, name, EMPTY_STR);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.skey); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.skey);
 }
 
 static void test_skey_null() {
@@ -55,7 +55,7 @@ static void test_skey_null() {
     const char *expected_value = NULL_STR;
 
     duo_common_ini_handler(&cfg, SECTION, name, NULL_STR);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.skey); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.skey);
 }
 
 /* Test adding apihost to duo_config */
@@ -66,16 +66,16 @@ static void test_host() {
     char *expected_value = "123412341234";
 
     duo_common_ini_handler(&cfg, SECTION, name, value);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.apihost); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.apihost);
 }
 
 static void test_host_empty() {
     struct duo_config cfg = {0};
     char *name = "host";
-    const char *expected_value = EMPTY_STR; 
-    
+    const char *expected_value = EMPTY_STR;
+
     duo_common_ini_handler(&cfg, SECTION, name, EMPTY_STR);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.apihost); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.apihost);
 }
 
 static void test_host_null() {
@@ -84,7 +84,7 @@ static void test_host_null() {
     const char *expected_value = NULL_STR;
 
     duo_common_ini_handler(&cfg, SECTION, name, NULL_STR);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.apihost); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.apihost);
 }
 
 /* Test adding cafile to duo_config */
@@ -95,16 +95,16 @@ static void test_cafile() {
     char *expected_value = "cafilevalue";
 
     duo_common_ini_handler(&cfg, SECTION, name, value);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.cafile); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.cafile);
 }
 
 static void test_cafile_empty() {
     struct duo_config cfg = {0};
     char *name = "cafile";
-    const char *expected_value = EMPTY_STR;    
+    const char *expected_value = EMPTY_STR;
 
     duo_common_ini_handler(&cfg, SECTION, name, EMPTY_STR);
-    TEST_ASSERT_EQUAL_STRING(EMPTY_STR, cfg.cafile); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.cafile);
 }
 
 static void test_cafile_null() {
@@ -124,7 +124,7 @@ static void test_http_proxy() {
     char *expected_value = "http://username:password@proxy.example.org:8080";
 
     duo_common_ini_handler(&cfg, SECTION, name, value);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.http_proxy); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.http_proxy);
 }
 
 static void test_http_proxy_empty() {
@@ -133,7 +133,7 @@ static void test_http_proxy_empty() {
     const char *expected_value = EMPTY_STR;
 
     duo_common_ini_handler(&cfg, SECTION, name, EMPTY_STR);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.http_proxy); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.http_proxy);
 }
 
 static void test_http_proxy_null() {
@@ -142,7 +142,7 @@ static void test_http_proxy_null() {
     const char *expected_value = NULL_STR;
 
     duo_common_ini_handler(&cfg, SECTION, name, NULL_STR);
-    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.http_proxy); 
+    TEST_ASSERT_EQUAL_STRING(expected_value, cfg.http_proxy);
 }
 
 int main() {
@@ -162,6 +162,6 @@ int main() {
     RUN_TEST(test_http_proxy);
     RUN_TEST(test_http_proxy_empty);
     RUN_TEST(test_http_proxy_null);
-    
+
     return UNITY_END();
 }


### PR DESCRIPTION
In order to better test Duo Unix we want to have coverage metrics this reduces the barrier to getting these metrics.

There is some permissions hackiness for reasons I wasn't quite able to determine. All of this is meant only as a tool for developers so at least it's confined. 
