### PR TITLE
Reset SIGPIPE handler on https_close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 /libtool
 /login_duo/login_duo
 /stamp-h1
+/tests/sigpipe
 /tests/testpam
 Makefile
 Makefile.in

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,6 +11,8 @@ check_LTLIBRARIES += liblogin_duo_preload.la
 liblogin_duo_preload_la_SOURCES = login_duo_preload.c
 liblogin_duo_preload_la_LDFLAGS = -no-undefined -avoid-version -rpath /baz -shared
 
+check_PROGRAMS = sigpipe
+
 if PAM
 TESTS += $(PAM_TESTS)
 
@@ -18,7 +20,7 @@ check_LTLIBRARIES += libtestpam_preload.la
 libtestpam_preload_la_SOURCES = testpam_preload.c
 libtestpam_preload_la_LDFLAGS = -no-undefined -avoid-version -rpath /bar -shared
 
-check_PROGRAMS = testpam
+check_PROGRAMS += testpam
 testpam_LDADD = -lpam
 endif
 

--- a/tests/sigpipe.c
+++ b/tests/sigpipe.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <unistd.h>
+#include <signal.h>
+
+#include <sys/wait.h>
+
+void usage(int argc, char *argv[]) {
+    fprintf(stderr, "usage: %s (run argv... | test)\n", argc ? argv[0] : "sigpipe");
+    exit(2);
+}
+
+int main(int argc, char *argv[]) {
+    pid_t pid;
+    int status;
+
+    if (argc < 2) {
+        usage(argc, argv);
+    }
+
+    if (strcmp(argv[1], "run") == 0) {
+        if (argc < 3) {
+            fprintf(stderr, "error: no program provided\n");
+            usage(argc, argv);
+        }
+        signal(SIGPIPE, SIG_DFL);
+        execvp(argv[2], argv + 2);
+        perror("execvp");
+        exit(1);
+    } else if (strcmp(argv[1], "test") == 0) {
+        if ((pid = fork()) < 0) {
+            perror("fork");
+            exit(1);
+        } else if (pid == 0) {
+            raise(SIGPIPE);
+        } else if (wait(&status) < 0) {
+            perror("wait");
+            exit(1);
+        } else if (WIFSIGNALED(status) && WTERMSIG(status) == SIGPIPE) {
+            printf("Success!\n");
+        } else {
+            printf("Failure\n");
+        }
+    }
+}

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -686,5 +686,17 @@ class TestMOTD(unittest.TestCase):
             self.assertEqual(process.expect("SUCCESS", timeout=10), 0)
 
 
+class TestSigpipe(unittest.TestCase):
+    def test_sigpipe(self):
+        with TempConfig(MOCKDUO_CONF) as temp:
+            self.assertEqual("Success!\n", subprocess.check_output([
+                os.path.join(TESTDIR, "sigpipe"), "run",
+                os.path.join(BUILDDIR, "login_duo", "login_duo"),
+                "-c", temp.name,
+                "-f", "preauth-allow",
+                os.path.join(TESTDIR, "sigpipe"), "test"
+            ]))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Issue
`https_init` sets the `SIGPIPE` handler to `SIG_IGN` without resetting it. This is inherited by `login_duo`'s child process (signal _handlers_ aren't inherited by child processes, but signal _dispositions_ are), leading to (in my case) strange problems with shell pipelines. I would imagine it would also cause problems for `pam_duo`, but I haven't tested that.

## Summary of the change
The handler is now established in `https_init`; the old handler is saved in the `https_request` and reset on `https_close`.

## Test Plan
Without patch, you can see that the ignored SIGPIPE is propagated to the child process:
```bash
$ login_duo -f asoutar grep SigIgn /proc/self/status
Autopushing login request to phone...
Success. Logging you in...
SigIgn:	0000000000001000
```
After patch, you can see that there are no longer ignored signals in the child:
```
$ login_duo -f asoutar grep SigIgn /proc/self/status
Autopushing login request to phone...
Success. Logging you in...
SigIgn:	0000000000000000
```