### PR TITLE
Convert tests to python 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install -y autoconf libtool libpam-dev libssl-dev automake python cppcheck
+        run: sudo apt-get update && sudo apt-get install -y autoconf libtool libpam-dev libssl-dev automake python3 cppcheck
 
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
         run: ./bootstrap && ./configure --with-pam --prefix=/usr && make CC=${{ matrix.cc }}
 
       - name: Run tests
-        run: make check
+        run: PYTHON=python3 make check
 
       - name: Static analysis
         run: cppcheck --quiet --force -i tests --suppressions-list=.false_positive.txt --error-exitcode=1 .

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -49,7 +49,7 @@ class CommonSuites:
         def test_missing_config_file(self):
             """Missing conf file"""
             result = self.call_binary(["-d", "-c", "/nonexistent", "true"])
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Couldn't open /nonexistent: No such file or directory",
             )
@@ -59,7 +59,7 @@ class CommonSuites:
             with TempConfig(TESTCONF) as temp:
                 os.chmod(temp.name, 0o644)
                 result = self.call_binary(["-d", "-c", temp.name, "true"])
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     "{name} must be readable only by user '.*'".format(name=temp.name),
                 )
@@ -73,7 +73,7 @@ class CommonSuites:
             ]:
                 with TempConfig(config) as temp:
                     result = self.call_binary(["-d", "-c", temp.name, "true"])
-                    self.assertRegexpMatches(
+                    self.assertRegex(
                         result["stderr"][0],
                         "Missing host, ikey, or skey in {name}".format(name=temp.name),
                     )
@@ -81,7 +81,7 @@ class CommonSuites:
         def test_corrupt_configuration_file_failsafe(self):
             with TempConfig(BAD_CORRUPT_CONF) as temp:
                 result = self.call_binary(["-d", "-c", temp.name, "true"])
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0], "Parse error in {name}".format(name=temp.name)
                 )
                 self.assertEqual(result["returncode"], 0)
@@ -89,7 +89,7 @@ class CommonSuites:
         def test_corrupt_configuration_file_failsecure(self):
             with TempConfig(BAD_CORRUPT_SECURE_CONF) as temp:
                 result = self.call_binary(["-d", "-c", temp.name, "true"])
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0], "Parse error in {name}".format(name=temp.name)
                 )
                 self.assertEqual(result["returncode"], 1)
@@ -101,7 +101,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "whatever", "true"]
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Failsafe Duo login for 'whatever'.*: Couldn't connect to .* Failed to connect",
                 )
@@ -114,14 +114,14 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "whatever", "true"]
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0], r"Couldn't open Duo API handle for .*"
                 )
                 self.assertEqual(result["returncode"], 1)
 
     class DuoSelfSignedCert(CommonTestCase):
         def run(self, result=None):
-            with MockDuo(SELFSIGNED_CERT):
+            with MockDuo(SELFSIGNED_CERT) as p:
                 return super(CommonSuites.DuoSelfSignedCert, self).run(result)
 
         def test_invalid_cert(self):
@@ -131,7 +131,7 @@ class CommonSuites:
                     result = self.call_binary(
                         ["-d", "-c", temp.name, "-f", "whatever", "true"]
                     )
-                    self.assertRegexpMatches(
+                    self.assertRegex(
                         result["stderr"][0],
                         r"{failmode} Duo login for .* Couldn't connect to .*: certificate verify failed".format(
                             failmode=config.failmode_as_prefix()
@@ -146,7 +146,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "preauth-allow", "true"]
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Skipped Duo login for 'preauth-allow'.*: preauth-allowed",
                 )
@@ -163,7 +163,7 @@ class CommonSuites:
                     result = self.call_binary(
                         ["-d", "-c", temp.name, "-f", "whatever", "true"]
                     )
-                    self.assertRegexpMatches(
+                    self.assertRegex(
                         result["stderr"][0],
                         r"{failmode} Duo login for .*: Couldn't connect to .*: Certificate name validation failed".format(
                             failmode=config.failmode_as_prefix()
@@ -178,7 +178,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "whatever", "true"]
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Failsecure Duo login for .*: Couldn't connect to .*: Certificate name validation failed",
                 )
@@ -189,7 +189,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "preauth-allow", "true"]
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Skipped Duo login for 'preauth-allow'.*: preauth-allowed",
                 )
@@ -206,7 +206,7 @@ class CommonSuites:
                         result = self.call_binary(
                             ["-d", "-c", temp.name, "-f", code, "true"]
                         )
-                        self.assertRegexpMatches(
+                        self.assertRegex(
                             result["stderr"][0],
                             r"Aborted Duo login for '{code}'.*: HTTP {code}".format(
                                 code=code
@@ -220,7 +220,7 @@ class CommonSuites:
                         result = self.call_binary(
                             ["-d", "-c", temp.name, "-f", code, "true"]
                         )
-                        self.assertRegexpMatches(
+                        self.assertRegex(
                             result["stderr"][0],
                             r"{failmode} Duo login for '{code}'.*: HTTP {code}".format(
                                 failmode=config.failmode_as_prefix(), code=code
@@ -234,7 +234,7 @@ class CommonSuites:
                     result = self.call_binary(
                         ["-d", "-c", temp.name, "-f", code, "true"]
                     )
-                    self.assertRegexpMatches(
+                    self.assertRegex(
                         result["stderr"][0],
                         r"{failmode} Duo login for '{code}'.*: Invalid ikey or skey".format(
                             failmode=config.failmode_as_prefix(), code=code
@@ -247,7 +247,7 @@ class CommonSuites:
                     result = self.call_binary(
                         ["-d", "-c", temp.name, "-f", "whatever", "true"]
                     )
-                    self.assertRegexpMatches(
+                    self.assertRegex(
                         result["stderr"][0],
                         r"{failmode} Duo login for .*: Invalid ikey or skey".format(
                             failmode=config.failmode_as_prefix()
@@ -267,7 +267,7 @@ class CommonSuites:
                     result = self.call_binary(
                         ["-d", "-c", temp.name, "-f", user, "true"]
                     )
-                    self.assertRegexpMatches(
+                    self.assertRegex(
                         result["stderr"][0],
                         r"{prefix} Duo login for '{user}'.*{message}".format(
                             prefix=prefix if prefix else config.failmode_as_prefix(),
@@ -317,7 +317,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "preauth-allow", "-h", host, "true"]
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Skipped Duo login for 'preauth-allow' from {host}: preauth-allowed".format(
                         host=host
@@ -345,7 +345,7 @@ class CommonSuites:
                     ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
                     env={},
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Skipped Duo login for 'preauth-allow'.*: preauth-allowed",
                 )
@@ -356,7 +356,7 @@ class CommonSuites:
                     ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
                     env={"http_proxy": "0.0.0.0"},
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Skipped Duo login for 'preauth-allow'.*: preauth-allowed",
                 )
@@ -366,7 +366,7 @@ class CommonSuites:
                     ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
                     env={"http_proxy": "0.0.0.0"},
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Failsafe Duo login for .*: Couldn't connect to localhost:4443: Failed to connect",
                 )
@@ -382,7 +382,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "hostname", "true"],
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Aborted Duo login for 'hostname': correct hostname",
                 )
@@ -403,7 +403,7 @@ class CommonSuites:
                     ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
                     timeout=10,
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Skipped Duo login for 'preauth-allow'.*: preauth-allowed",
                 )
@@ -416,7 +416,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     "FIPS mode flag specified, but OpenSSL not built with FIPS support. Failing the auth.",
                 )
@@ -432,7 +432,7 @@ class CommonSuites:
                     result = self.call_binary(
                         ["-d", "-c", temp.name, "-f", "auth_timeout", "true"],
                     )
-                    self.assertRegexpMatches(
+                    self.assertRegex(
                         result["stderr"][0],
                         r"Error in Duo login for 'auth_timeout': HTTP 500",
                     )
@@ -442,7 +442,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "failopen", "true"],
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Aborted Duo login for 'failopen': correct failmode",
                 )
@@ -452,7 +452,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "failclosed", "true"],
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Aborted Duo login for 'failclosed': correct failmode",
                 )
@@ -462,7 +462,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "enroll", "true"],
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"User enrollment required",
                 )
@@ -491,7 +491,7 @@ class CommonSuites:
                     },
                     timeout=15,
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Skipped Duo login for 'preauth-allow'.*: preauth-allowed",
                 )
@@ -504,7 +504,7 @@ class CommonSuites:
                         "SSH_CONNECTION": "1.2.3.4",
                     },
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r" Skipped Duo login for 'preauth-allow'",
                 )
@@ -514,7 +514,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "preauth-allow", "true"]
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Skipped Duo login for 'preauth-allow'.*: preauth-allowed",
                 )
@@ -550,7 +550,7 @@ class CommonSuites:
                 self.assertOutputEqual(
                     process.match.group(0), CommonSuites.Interactive.PROMPT_TEXT
                 )
-                process.sendline("123456")
+                process.sendline(b"123456")
                 self.assertEqual(
                     process.expect(CommonSuites.Interactive.PROMPT_REGEX, timeout=1), 0
                 )
@@ -563,7 +563,7 @@ class CommonSuites:
                     ]
                     + CommonSuites.Interactive.PROMPT_TEXT,
                 )
-                process.sendline("wefawefgoiagj3rj")
+                process.sendline(b"wefawefgoiagj3rj")
                 self.assertEqual(
                     process.expect(CommonSuites.Interactive.PROMPT_REGEX, timeout=1), 0
                 )
@@ -576,7 +576,7 @@ class CommonSuites:
                     ]
                     + CommonSuites.Interactive.PROMPT_TEXT,
                 )
-                process.sendline("A" * 500)
+                process.sendline(b"A" * 500)
                 self.assertEqual(process.expect(pexpect.EOF), 0)
                 self.maxDiff = None
                 self.assertOutputEqual(
@@ -598,7 +598,7 @@ class CommonSuites:
                 self.assertOutputEqual(
                     process.match.group(0), CommonSuites.Interactive.PROMPT_TEXT
                 )
-                process.sendline("3")
+                process.sendline(b"3")
                 self.assertEqual(
                     process.expect(CommonSuites.Interactive.PROMPT_REGEX, timeout=5), 0
                 )
@@ -611,7 +611,7 @@ class CommonSuites:
                     ]
                     + CommonSuites.Interactive.PROMPT_TEXT,
                 )
-                process.sendline("4")
+                process.sendline(b"4")
                 self.assertEqual(
                     process.expect(CommonSuites.Interactive.PROMPT_REGEX, timeout=5), 0
                 )
@@ -626,7 +626,7 @@ class CommonSuites:
                     ]
                     + CommonSuites.Interactive.PROMPT_TEXT,
                 )
-                process.sendline("1")
+                process.sendline(b"1")
                 self.assertEqual(process.expect(pexpect.EOF), 0)
                 self.assertOutputEqual(
                     process.before,
@@ -645,7 +645,7 @@ class CommonSuites:
                 )
                 # This is here to prevent race conditions with character entry
                 process.expect(CommonSuites.Interactive.PROMPT_REGEX, timeout=10)
-                process.sendline("2")
+                process.sendline(b"2")
                 self.assertEqual(process.expect(pexpect.EOF), 0)
                 self.assertOutputEqual(
                     process.before,
@@ -698,7 +698,7 @@ class CommonSuites:
                 result = self.call_binary(
                     ["-d", "-c", temp.name, "-f", "bad-json", "true"],
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"invalid JSON response",
                 )

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 

--- a/tests/login_duo.py
+++ b/tests/login_duo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import platform

--- a/tests/login_duo.py
+++ b/tests/login_duo.py
@@ -1,31 +1,34 @@
 #!/usr/bin/env python
 
 import os
+import platform
 import subprocess
 import sys
-import platform
 
 import paths
+
 
 def main():
     env = os.environ.copy()
 
-    if sys.platform == 'darwin':
-        env['DYLD_LIBRARY_PATH'] = paths.topbuilddir + '/lib/.libs'
-        env['DYLD_INSERT_LIBRARIES'] = paths.build + \
-                                       '/.libs/liblogin_duo_preload.dylib'
-        env['DYLD_FORCE_FLAT_NAMESPACE'] = '1'
-    elif sys.platform == 'sunos5':
-        architecture = {'32bit': '32', '64bit': '64'}[platform.architecture()[0]]
-        env['LD_PRELOAD_' + architecture] = paths.build + '/.libs/liblogin_duo_preload.so'
+    if sys.platform == "darwin":
+        env["DYLD_LIBRARY_PATH"] = paths.topbuilddir + "/lib/.libs"
+        env["DYLD_INSERT_LIBRARIES"] = paths.build + "/.libs/liblogin_duo_preload.dylib"
+        env["DYLD_FORCE_FLAT_NAMESPACE"] = "1"
+    elif sys.platform == "sunos5":
+        architecture = {"32bit": "32", "64bit": "64"}[platform.architecture()[0]]
+        env["LD_PRELOAD_" + architecture] = (
+            paths.build + "/.libs/liblogin_duo_preload.so"
+        )
     else:
-        env['LD_PRELOAD'] = paths.build + '/.libs/liblogin_duo_preload.so'
+        env["LD_PRELOAD"] = paths.build + "/.libs/liblogin_duo_preload.so"
 
-    args = [ paths.login_duo ] + sys.argv[1:]
+    args = [paths.login_duo] + sys.argv[1:]
     p = subprocess.Popen(args, env=env)
     p.wait()
-    
+
     sys.exit(p.returncode)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/tests/login_duo_preload.c
+++ b/tests/login_duo_preload.c
@@ -36,7 +36,7 @@ static struct passwd _passwd[11] = {
         { "fullgecos", "*", 1014, 100, .pw_gecos = "full_gecos_field", .pw_dir = "/", .pw_shell = "/bin/sh" },
         { "noshell", "*", 1015, 100, .pw_gecos = "full_gecos_field", .pw_dir = "/", .pw_shell = NULL},
         { "emptygecos", "*", 1016, 100, .pw_gecos = "", .pw_dir = "/", .pw_shell = "/bin/sh" },
-        { "slashshell", "*", 1017, 100, .pw_gecos = "full_gecos_field", .pw_dir = "/", .pw_shell = "/usr/bin/echo"},
+        { "slashshell", "*", 1017, 100, .pw_gecos = "full_gecos_field", .pw_dir = "/", .pw_shell = "/bin/echo"},
         { "preauth-allow", "*", 1018, 100, .pw_gecos = "gecos", .pw_dir = "/",
           .pw_shell = "/bin/sh" },
 };

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import cgi
 import json

--- a/tests/mockduo_context.py
+++ b/tests/mockduo_context.py
@@ -61,7 +61,7 @@ class MockDuoTimeoutException(MockDuoException):
 class MockDuo:
     def __init__(self, cert=NORMAL_CERT):
         self.cert = cert
-        self.cmd = ["python", os.path.join(TESTDIR, "mockduo.py"), self.cert]
+        self.cmd = ["python3", os.path.join(TESTDIR, "mockduo.py"), self.cert]
         self.process = None
 
     def __enter__(self):

--- a/tests/mockduo_context.py
+++ b/tests/mockduo_context.py
@@ -17,11 +17,11 @@ def port_open(ip, port):
     try:
         s.connect((ip, int(port)))
         s.shutdown(2)
-        s.close()
         return True
     except:
-        s.close()
         return False
+    finally:
+        s.close()
 
 
 class MockDuoException(Exception):
@@ -81,7 +81,10 @@ class MockDuo:
             stdout = self.process.stdout.read().decode("utf-8")
             self.process.stderr.close()
             self.process.stdout.close()
-            self.process.stdin.close()
+
+            if self.process.stdin:
+                self.process.stdin.close()
+
             self.process.wait()
             raise MockDuoTimeoutException(
                 returncode=None,

--- a/tests/mocklogin_duo.py
+++ b/tests/mocklogin_duo.py
@@ -1,58 +1,59 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
-import pexpect
 import sys
 
 import paths
+import pexpect
 
-PROMPT = '.* or option \(1-4\): $'
+PROMPT = ".* or option \(1-4\): $"
+
 
 def _login_duo(confs):
-    p = pexpect.spawn(paths.login_duo + ' -d -c' + confs + \
-                      ' -f foobar echo SUCCESS')
+    p = pexpect.spawn(paths.login_duo + " -d -c" + confs + " -f foobar echo SUCCESS")
     p.expect(PROMPT, timeout=10)
-    print '===> %r' % p.match.group(0)
+    print "===> %r" % p.match.group(0)
     return p
+
 
 def main():
     confs = sys.argv[1]
     p = _login_duo(confs)
 
     # 3 failures in a row
-    p.sendline('123456')
+    p.sendline("123456")
     p.expect(PROMPT)
-    print '===> %r' % p.match.group(0)
-    
-    p.sendline('wefawefgoiagj3rj')
+    print "===> %r" % p.match.group(0)
+
+    p.sendline("wefawefgoiagj3rj")
     p.expect(PROMPT)
-    print '===> %r' % p.match.group(0)
-    
-    p.sendline('A' * 500)
+    print "===> %r" % p.match.group(0)
+
+    p.sendline("A" * 500)
     p.expect(pexpect.EOF)
-    print '===> %r' % p.before
+    print "===> %r" % p.before
 
     # menu options
     p = _login_duo(confs)
 
-    p.sendline('3')
+    p.sendline("3")
     p.expect(PROMPT)
-    print '===> %r' % p.match.group(0)
-    
-    p.sendline('4')
-    p.expect(PROMPT)
-    print '===> %r' % p.match.group(0)
+    print "===> %r" % p.match.group(0)
 
-    p.sendline('1')
+    p.sendline("4")
+    p.expect(PROMPT)
+    print "===> %r" % p.match.group(0)
+
+    p.sendline("1")
     p.expect(pexpect.EOF)
-    print '===> %r' % p.before
-    
+    print "===> %r" % p.before
+
     p = _login_duo(confs)
-    
-    p.sendline('2')
+
+    p.sendline("2")
     p.expect(pexpect.EOF)
-    print '===> %r' % p.before
+    print "===> %r" % p.before
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()
-

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import subprocess
 import unittest

--- a/tests/test_duo_split_at.py
+++ b/tests/test_duo_split_at.py
@@ -9,9 +9,13 @@ BUILDDIR = topbuilddir
 
 
 def testutil_duo_split_at(args):
-    return subprocess.check_output(
-        [os.path.join(BUILDDIR, "lib", "testutil_duo_split_at")] + args
-    ).strip()
+    return (
+        subprocess.check_output(
+            [os.path.join(BUILDDIR, "lib", "testutil_duo_split_at")] + args
+        )
+        .decode("utf-8")
+        .strip()
+    )
 
 
 class TestDuoSplitAt(unittest.TestCase):

--- a/tests/test_duo_split_at.py
+++ b/tests/test_duo_split_at.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import subprocess
 import unittest

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import subprocess
 import sys

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -70,7 +70,7 @@ def login_duo_interactive(args, env=None, preload_script=""):
     env_passthrough.update(env)
 
     if preload_script != "":
-        login_duo_path = "python"
+        login_duo_path = "python3"
         args = [preload_script] + args
     else:
         login_duo_path = os.path.join(BUILDDIR, "login_duo", "login_duo")
@@ -94,7 +94,7 @@ def login_duo(args, env=None, timeout=10, preload_script=""):
         env = {}
 
     if preload_script != "":
-        login_duo_path = ["python", preload_script]
+        login_duo_path = ["python3", preload_script]
     else:
         login_duo_path = [os.path.join(BUILDDIR, "login_duo", "login_duo")]
 

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -126,10 +126,15 @@ def login_duo(args, env=None, timeout=10, preload_script=""):
             "login_duo unexpectedly blocked for user input", stdout, stderr
         )
 
+    stdout = process.stdout.read().decode("utf-8").split("\n")
+    stderr = process.stderr.read().decode("utf-8").split("\n")
+    process.stdout.close()
+    process.stderr.close()
+    process.stdin.close()
     return {
         "returncode": process.returncode,
-        "stdout": process.stdout.read().split(b"\n"),
-        "stderr": process.stderr.read().split(b"\n"),
+        "stdout": stdout,
+        "stderr": stderr,
     }
 
 
@@ -197,7 +202,7 @@ class TestLoginDuoConfig(unittest.TestCase):
     def test_empty_args(self):
         """Test to see how login_duo handles an empty string argument (we do need a valid argument also)"""
         result = login_duo(["", "-h"])
-        self.assertRegexpMatches(
+        self.assertRegex(
             result["stderr"][0], ".*login_duo: option requires an argument.*"
         )
         self.assertEqual(
@@ -209,7 +214,7 @@ class TestLoginDuoConfig(unittest.TestCase):
     def test_help_output(self):
         """Basic help output"""
         result = login_duo(["-h"])
-        self.assertRegexpMatches(
+        self.assertRegex(
             result["stderr"][0], ".*login_duo: option requires an argument.*"
         )
         self.assertEqual(
@@ -221,7 +226,7 @@ class TestLoginDuoConfig(unittest.TestCase):
     def test_version_output(self):
         """Check version output"""
         result = login_duo(["-v"])
-        self.assertRegexpMatches(result["stderr"][0], "login_duo \d+\.\d+.\d+")
+        self.assertRegex(result["stderr"][0], "login_duo \d+\.\d+.\d+")
 
 
 class TestLoginDuoEnv(CommonSuites.Env):
@@ -243,7 +248,7 @@ class TestLoginDuoSpecificEnv(unittest.TestCase):
                 },
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Who are you?",
             )
@@ -258,7 +263,7 @@ class TestLoginDuoSpecificEnv(unittest.TestCase):
                 },
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stdout"][0],
                 r"hello",
             )
@@ -298,7 +303,7 @@ class TestLoginDuoUIDMismatch(unittest.TestCase):
                 },
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Only root may specify -c or -f",
             )
@@ -308,7 +313,7 @@ class TestLoginDuoUIDMismatch(unittest.TestCase):
             result = login_duo(
                 ["-d", "-c", temp.name, "-f", "whatever", "true"],
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Successful Duo login for 'whatever'",
             )
@@ -324,7 +329,7 @@ class TestLoginDuoUIDMismatch(unittest.TestCase):
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
                 timeout=10,
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"couldn't drop privileges:",
             )
@@ -341,7 +346,7 @@ class TestLoginDuoUIDMismatch(unittest.TestCase):
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
                 timeout=10,
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"User .* not found",
             )
@@ -365,7 +370,7 @@ class TestLoginDuoTimeout(unittest.TestCase):
             )
             for line in result["stderr"][:3]:
                 self.assertEqual(line, "Attempting connection")
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][3],
                 r"Failsafe Duo login for 'timeout': Couldn't connect to localhost:4443: Failed to connect",
             )
@@ -412,7 +417,7 @@ class TestLoginDuoGroups(unittest.TestCase):
                     },
                     preload_script=os.path.join(TESTDIR, "groups.py"),
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Skipped Duo login for 'preauth-allow': preauth-allowed",
                 )
@@ -427,7 +432,7 @@ class TestLoginDuoGroups(unittest.TestCase):
                     },
                     preload_script=os.path.join(TESTDIR, "groups.py"),
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][0],
                     r"Skipped Duo login for 'preauth-allow': preauth-allowed",
                 )
@@ -441,7 +446,7 @@ class TestLoginDuoGroups(unittest.TestCase):
                 },
                 preload_script=os.path.join(TESTDIR, "groups.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Skipped Duo login for 'preauth-allow': preauth-allowed",
             )
@@ -453,7 +458,7 @@ class TestLoginDuoGroups(unittest.TestCase):
                 env={"UID": "1004"},
                 preload_script=os.path.join(TESTDIR, "groups.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"User preauth-allow bypassed Duo 2FA due to user's UNIX group",
             )
@@ -476,7 +481,7 @@ class TestLoginDuoGECOS(unittest.TestCase):
                 env={"UID": "1010"},
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Successful Duo login for '1/2/3/4/5/gecos_user_gecos_field6'",
             )
@@ -488,11 +493,11 @@ class TestLoginDuoGECOS(unittest.TestCase):
                 env={"UID": "1010"},
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"The gecos_parsed configuration item for Duo Unix is deprecated and no longer has any effect. Use gecos_delim and gecos_username_pos instead",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][1],
                 "Skipped Duo login for 'gecos/6': gecos/6",
             )
@@ -504,7 +509,7 @@ class TestLoginDuoGECOS(unittest.TestCase):
                 env={"UID": "1012"},
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 "Skipped Duo login for 'gecos_user_gecos_field6': gecos-user-gecos-field6-allowed",
             )
@@ -516,7 +521,7 @@ class TestLoginDuoGECOS(unittest.TestCase):
                 env={"UID": "1011"},
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Skipped Duo login for 'gecos_user_gecos_field3': gecos-user-gecos-field3-allowed",
             )
@@ -528,7 +533,7 @@ class TestLoginDuoGECOS(unittest.TestCase):
                 env={"UID": "1012"},
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Could not parse GECOS field",
             )
@@ -540,7 +545,7 @@ class TestLoginDuoGECOS(unittest.TestCase):
                 env={"UID": "1016"},
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Empty GECOS field",
             )
@@ -550,15 +555,15 @@ class TestLoginDuoGECOS(unittest.TestCase):
             result = login_duo(
                 ["-d", "-c", temp.name, "true"],
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Invalid character option length. Character fields must be 1 character long: ',,'",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][1],
                 r"Invalid login_duo option: 'gecos_delim'",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][2],
                 r"Parse error in {config}, line \d+".format(config=temp.name),
             )
@@ -572,17 +577,17 @@ class TestLoginDuoGECOS(unittest.TestCase):
                 result = login_duo(
                     ["-d", "-c", temp.name, "true"],
                 )
-                self.assertEquals(
+                self.assertEqual(
                     result["stderr"][0],
                     "Invalid gecos_delim '{delim}' (delimiter must be punctuation other than ':')".format(
                         delim=config["gecos_delim"]
                     ),
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][1],
                     r"Invalid login_duo option: 'gecos_delim'",
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][2],
                     r"Parse error in {config}, line \d+".format(config=temp.name),
                 )
@@ -592,15 +597,15 @@ class TestLoginDuoGECOS(unittest.TestCase):
             result = login_duo(
                 ["-d", "-c", temp.name, "true"],
             )
-            self.assertEquals(
+            self.assertEqual(
                 result["stderr"][0],
                 "Invalid character option length. Character fields must be 1 character long: ''",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][1],
                 r"Invalid login_duo option: 'gecos_delim'",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][2],
                 r"Parse error in {config}, line \d+".format(config=temp.name),
             )
@@ -610,15 +615,15 @@ class TestLoginDuoGECOS(unittest.TestCase):
             result = login_duo(
                 ["-d", "-c", temp.name, "true"],
             )
-            self.assertEquals(
+            self.assertEqual(
                 result["stderr"][0],
                 "Gecos position starts at 1",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][1],
                 r"Invalid login_duo option: 'gecos_username_pos'",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][2],
                 r"Parse error in {config}, line \d+".format(config=temp.name),
             )
@@ -646,7 +651,7 @@ class TestMOTD(unittest.TestCase):
                 },
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            process.sendline("1")
+            process.sendline(b"1")
             self.assertEqual(process.expect("test_string", timeout=10), 0)
 
     def test_motd_with_ssh_command(self):
@@ -660,7 +665,7 @@ class TestMOTD(unittest.TestCase):
                 env={"UID": "1001", "SSH_ORIGINAL_COMMAND": "ls"},
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
             )
-            process.sendline("1")
+            process.sendline(b"1")
             self.assertEqual(process.expect([test_motd, pexpect.EOF], timeout=5), 1)
 
     def test_motd_users_bypass(self):
@@ -681,7 +686,7 @@ class TestMOTD(unittest.TestCase):
                 },
                 preload_script=os.path.join(TESTDIR, "groups.py"),
             )
-            process.sendline("1")
+            process.sendline(b"1")
             self.assertEqual(process.expect("test_string", timeout=10), 0)
             self.assertEqual(process.expect("SUCCESS", timeout=10), 0)
 

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -104,7 +104,10 @@ def pam_duo(args, env={}, timeout=2):
     process.stdout.close()
     process.stderr.close()
     process.stdin.close()
-    process.terminate()
+    try:
+        process.terminate()
+    except:
+        pass
     return {
         "returncode": process.returncode,
         "stdout": stdout_lines,

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -98,17 +98,24 @@ def pam_duo(args, env={}, timeout=2):
         (stdout, stderr) = process.communicate(input=b"1\r\n")
         raise PamDuoTimeoutException(stdout, stderr)
 
+    stdout_lines = process.stdout.read().decode("utf-8").split("\n")
+    stderr_lines = process.stderr.read().decode("utf-8").split("\n")
+
+    process.stdout.close()
+    process.stderr.close()
+    process.stdin.close()
+    process.terminate()
     return {
         "returncode": process.returncode,
-        "stdout": process.stdout.read().split(b"\n"),
-        "stderr": process.stderr.read().split(b"\n"),
+        "stdout": stdout_lines,
+        "stderr": stderr_lines,
     }
 
 
 class TestPamDuoHelp(unittest.TestCase):
     def test_help(self):
         result = pam_duo(["-h"])
-        self.assertRegexpMatches(
+        self.assertRegex(
             result["stderr"][0],
             r"Usage: .*/tests/testpam.py \[-d\] \[-c config\] \[-f user\] \[-h host\]",
         )
@@ -177,29 +184,25 @@ class TestPamPrompts(unittest.TestCase):
     def test_max_prompts_equals_one(self):
         with TempConfig(MOCKDUO_PROMPTS_1) as temp:
             result = pam_duo(["-d", "-f", "pam_prompt", "-c", temp.name, "true"])
-            self.assertRegexpMatches(
-                result["stderr"][0], "Failed Duo login for 'pam_prompt'"
-            )
-            self.assertRegexpMatches(
+            self.assertRegex(result["stderr"][0], "Failed Duo login for 'pam_prompt'")
+            self.assertRegex(
                 result["stdout"][0], "Autopushing login request to phone..."
             )
-            self.assertRegexpMatches(
-                result["stdout"][1], "Invalid passcode, please try again."
-            )
+            self.assertRegex(result["stdout"][1], "Invalid passcode, please try again.")
 
     def test_max_prompts_equals_maximum(self):
         with TempConfig(MOCKDUO_PROMPTS_DEFAULT) as temp:
             result = pam_duo(["-d", "-f", "pam_prompt", "-c", temp.name, "true"])
             for i in range(0, 3):
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][i], "Failed Duo login for 'pam_prompt'"
                 )
 
             for i in range(0, 6, 2):
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stdout"][i], "Autopushing login request to phone..."
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stdout"][i + 1], "Invalid passcode, please try again."
                 )
 
@@ -247,7 +250,7 @@ class TestPamDuoInteractive(CommonSuites.Interactive):
             )
             # This is here to prevent race conditions with character entry
             process.expect(CommonSuites.Interactive.PROMPT_REGEX, timeout=10)
-            process.sendline("2")
+            process.sendline(b"2")
             self.assertEqual(process.expect(pexpect.EOF), 0)
             user = getpass.getuser()
             self.assertOutputEqual(
@@ -286,7 +289,7 @@ class TestPamGECOS(unittest.TestCase):
             result = pam_duo(
                 ["-d", "-c", temp.name, "-f", "fullgecos", "true"],
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Skipped Duo login for 'full_gecos_field': full-gecos-field",
             )
@@ -296,11 +299,11 @@ class TestPamGECOS(unittest.TestCase):
             result = pam_duo(
                 ["-d", "-c", temp.name, "-f", "gecos/6", "true"],
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"The gecos_parsed configuration item for Duo Unix is deprecated and no longer has any effect. Use gecos_delim and gecos_username_pos instead",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][1],
                 "Skipped Duo login for 'gecos/6': gecos/6",
             )
@@ -310,7 +313,7 @@ class TestPamGECOS(unittest.TestCase):
             result = pam_duo(
                 ["-d", "-c", temp.name, "-f", "gecos,6", "true"],
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 "Skipped Duo login for 'gecos_user_gecos_field6': gecos-user-gecos-field6-allowed",
             )
@@ -320,7 +323,7 @@ class TestPamGECOS(unittest.TestCase):
             result = pam_duo(
                 ["-d", "-c", temp.name, "-f", "gecos/3", "true"],
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Skipped Duo login for 'gecos_user_gecos_field3': gecos-user-gecos-field3-allowed",
             )
@@ -330,15 +333,15 @@ class TestPamGECOS(unittest.TestCase):
             result = pam_duo(
                 ["-d", "-c", temp.name, "true"],
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][0],
                 r"Invalid character option length. Character fields must be 1 character long: ',,'",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][1],
                 r"Invalid pam_duo option: 'gecos_delim'",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][2],
                 r"Parse error in {config}, line \d+".format(config=temp.name),
             )
@@ -352,17 +355,17 @@ class TestPamGECOS(unittest.TestCase):
                 result = pam_duo(
                     ["-d", "-c", temp.name, "true"],
                 )
-                self.assertEquals(
+                self.assertEqual(
                     result["stderr"][0],
                     "Invalid gecos_delim '{delim}' (delimiter must be punctuation other than ':')".format(
                         delim=config["gecos_delim"]
                     ),
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][1],
                     r"Invalid pam_duo option: 'gecos_delim'",
                 )
-                self.assertRegexpMatches(
+                self.assertRegex(
                     result["stderr"][2],
                     r"Parse error in {config}, line \d+".format(config=temp.name),
                 )
@@ -372,15 +375,15 @@ class TestPamGECOS(unittest.TestCase):
             result = pam_duo(
                 ["-d", "-c", temp.name, "true"],
             )
-            self.assertEquals(
+            self.assertEqual(
                 result["stderr"][0],
                 "Invalid character option length. Character fields must be 1 character long: ''",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][1],
                 r"Invalid pam_duo option: 'gecos_delim'",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][2],
                 r"Parse error in {config}, line \d+".format(config=temp.name),
             )
@@ -390,15 +393,15 @@ class TestPamGECOS(unittest.TestCase):
             result = pam_duo(
                 ["-d", "-c", temp.name, "true"],
             )
-            self.assertEquals(
+            self.assertEqual(
                 result["stderr"][0],
                 "Gecos position starts at 1",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][1],
                 r"Invalid pam_duo option: 'gecos_username_pos'",
             )
-            self.assertRegexpMatches(
+            self.assertRegex(
                 result["stderr"][2],
                 r"Parse error in {config}, line \d+".format(config=temp.name),
             )

--- a/tests/testpam.py
+++ b/tests/testpam.py
@@ -15,7 +15,10 @@ import paths
 
 
 def usage():
-    print >>sys.stderr, "Usage: %s [-d] [-c config] [-f user] [-h host]" % sys.argv[0]
+    print(
+        "Usage: {0} [-d] [-c config] [-f user] [-h host]".format(sys.argv[0]),
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 

--- a/tests/testpam.py
+++ b/tests/testpam.py
@@ -27,8 +27,8 @@ class TempPamConfig(object):
     def __enter__(self):
         self.file = tempfile.NamedTemporaryFile()
         if sys.platform == "sunos5":
-            self.file.write("testpam ")
-        self.file.write(self.config)
+            self.file.write(b"testpam ")
+        self.file.write(self.config.encode("utf-8"))
         self.file.flush()
         return self.file
 

--- a/tests/testpam.py
+++ b/tests/testpam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import getopt


### PR DESCRIPTION
Since python 2 is EOL these tests should run on python 3. This also allows Duo Unix to more easily be tested on modern images that may not have python 2.
