### PR TITLE
Change PAM preload hacks in favor of fake service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: ./bootstrap && ./configure --with-pam --prefix=/usr && make CC=${{ matrix.cc }}
 
       - name: Run tests
-        run: PYTHON=python3 make check
+        run: sudo make check
 
       - name: Static analysis
         run: cppcheck --quiet --force -i tests --suppressions-list=.false_positive.txt --error-exitcode=1 .

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ sudo apt-get install python
 
 To run all the automated tests simply run
 ```
-$ make check
+$ sudo make check
 ```
 To run an individual test file
 ```

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -167,7 +167,7 @@ do_auth(struct login_ctx *ctx, const char *cmd)
         }
         return (EXIT_FAILURE);
     }
-    
+
 
 #ifdef OPENSSL_FIPS
     /*
@@ -179,12 +179,12 @@ do_auth(struct login_ctx *ctx, const char *cmd)
      * example, when integrating directly with the OpenSSL FIPS Object Module).
      */
     if(!FIPS_mode_set(cfg.fips_mode)) {
-        /* The smallest size buff can be according to the openssl docs */ 
+        /* The smallest size buff can be according to the openssl docs */
         char buff[256];
         int error = ERR_get_error();
         ERR_error_string_n(error, buff, sizeof(buff));
         duo_syslog(LOG_ERR, "Unable to start fips_mode: %s", buff);
-	 
+
        return (EXIT_FAILURE);
     }
 #else

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -29,7 +29,6 @@ from mockduo_context import NORMAL_CERT, SELFSIGNED_CERT, WRONGHOST_CERT, MockDu
 
 TESTDIR = os.path.realpath(os.path.dirname(__file__))
 
-
 def fips_available():
     returncode = subprocess.call(
         [os.path.join(TESTDIR, "is_fips_supported.sh")],

--- a/tests/groups_preload.c
+++ b/tests/groups_preload.c
@@ -110,13 +110,15 @@ getgrent(void)
 FILE *
 fopen(const char *filename, const char *mode)
 {
-    _fopen = dlsym(RTLD_NEXT, "fopen");
     if (strcmp(filename, "/etc/motd") == 0) {
-        return (*_fopen)("/tmp/duomotdtest", mode);
+        char *m = getenv("MOTD_FILE");
+        if(m) {
+            _fopen = dlsym(RTLD_NEXT, "fopen");
+            return (*_fopen)(m, mode);
+        }
     }
-    else {
-        return (*_fopen)(filename, mode);
-    }
+    _fopen = dlsym(RTLD_NEXT, "fopen");
+    return (*_fopen)(filename, mode);
 }
 
 int

--- a/tests/is_fips_supported.sh
+++ b/tests/is_fips_supported.sh
@@ -5,7 +5,7 @@
 # We also echo the return code before exiting since there's no good way to capture it
 # without some actual output in cram :(
 
-FIPS_VALIDATED_DISTROS=("centos8" "rhel8" "centos7" "rhel7" "centos6" "rhel6")
+FIPS_VALIDATED_DISTROS=("centos8" "rhel8" "centos7" "rhel7" "centos6" "rhel6", "fedora34")
 
 # We can't use uname since that won't work with Docker images.
 # See https://stackoverflow.com/questions/31012297/uname-a-returning-the-same-in-docker-host-or-any-docker-container for more details.

--- a/tests/login_duo_preload.c
+++ b/tests/login_duo_preload.c
@@ -163,11 +163,13 @@ getpwnam(const char *name)
 FILE *
 fopen(const char *filename, const char *mode)
 {
-    _fopen = dlsym(RTLD_NEXT, "fopen");
     if (strcmp(filename, "/etc/motd") == 0) {
-        return (*_fopen)("/tmp/duomotdtest", mode);
+        char *m = getenv("MOTD_FILE");
+        if(m) {
+            _fopen = dlsym(RTLD_NEXT, "fopen");
+            return (*_fopen)(m, mode);
+        }
     }
-    else {
-        return (*_fopen)(filename, mode);
-    }
+    _fopen = dlsym(RTLD_NEXT, "fopen");
+    return (*_fopen)(filename, mode);
 }

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -3,7 +3,6 @@
 import cgi
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Dict, Union
 
 try:
     from hashlib import sha1
@@ -50,7 +49,6 @@ tx_msgs = {
 class MockDuoHandler(BaseHTTPRequestHandler):
     server_version = "MockDuo/1.0"
     protocol_version = "HTTP/1.1"
-    ret: Dict[str, Union[str, Dict]]
 
     def _verify_sig(self):
         authz = base64.b64decode(self.headers["Authorization"].split()[1]).decode(

--- a/tests/mockduo_context.py
+++ b/tests/mockduo_context.py
@@ -17,8 +17,10 @@ def port_open(ip, port):
     try:
         s.connect((ip, int(port)))
         s.shutdown(2)
+        s.close()
         return True
     except:
+        s.close()
         return False
     finally:
         s.close()

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import getpass
 import os
 import subprocess
@@ -232,7 +232,7 @@ class TestPamSpecificEnv(unittest.TestCase):
         with TempConfig(MOCKDUO_CONF) as temp:
             result = pam_duo(
                 ["-d", "-c", temp.name],
-                env={"PAM_SERVICE": "su", "NO_USER": "1"},
+                env={"SIMULATE_SERVICE": "su", "NO_USER": "1"},
             )
             self.assertEqual(result["returncode"], 1)
 
@@ -251,7 +251,7 @@ class TestPamDuoInteractive(CommonSuites.Interactive):
         with TempConfig(MOCKDUO_CONF) as temp:
             process = self.call_binary(
                 ["-d", "-c", temp.name, "-f", "foobar", "true"],
-                env={"PAM_SERVICE": "su"},
+                env={"SIMULATE_SERVICE": "su"},
             )
             # This is here to prevent race conditions with character entry
             process.expect(CommonSuites.Interactive.PROMPT_REGEX, timeout=10)

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -104,10 +104,12 @@ def pam_duo(args, env={}, timeout=2):
     process.stdout.close()
     process.stderr.close()
     process.stdin.close()
+
     try:
         process.terminate()
     except:
         pass
+
     return {
         "returncode": process.returncode,
         "stdout": stdout_lines,

--- a/tests/testpam.c
+++ b/tests/testpam.c
@@ -88,12 +88,6 @@ die(pam_handle_t *pamh, int errnum)
         exit(EXIT_FAILURE);
 }
 
-static char*
-service_name() {
-    char *t = getenv("PAM_SERVICE");
-    return (t ? t : "testpam");
-}
-
 int
 main(int argc, char *argv[])
 {
@@ -109,7 +103,7 @@ main(int argc, char *argv[])
     if (argc > 2)
         host = argv[2];
 
-    if ((ret = pam_start(service_name(), user, &conv, &pamh)) != PAM_SUCCESS) {
+    if ((ret = pam_start("test_duo_unix_service", user, &conv, &pamh)) != PAM_SUCCESS) {
                 die(pamh, ret);
     }
     if (host != NULL) {

--- a/tests/testpam_preload.c
+++ b/tests/testpam_preload.c
@@ -18,6 +18,16 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#ifdef HAVE_SECURITY_PAM_APPL_H
+#include <security/pam_appl.h>
+#endif
+#ifdef HAVE_SECURITY_PAM_MODULES_H
+#include <security/pam_modules.h>
+#endif
+#ifdef HAVE_SECURITY_PAM_EXT_H
+#include <security/pam_ext.h>  /* Linux-PAM */
+#endif
+
 #ifdef __APPLE__
 # define _PATH_LIBC       "libc.dylib"
 #elif defined(__linux__)
@@ -26,88 +36,21 @@
 # define _PATH_LIBC       "libc.so"
 #endif
 
-static void _preload_init(void) __attribute((constructor));
-
 int (*_sys_open)(const char *pathname, int flags, ...);
 int (*_sys_open64)(const char *pathname, int flags, ...);
 FILE *(*_sys_fopen)(const char *filename, const char *mode);
 FILE *(*_sys_fopen64)(const char *filename, const char *mode);
 char *(*_sys_inet_ntoa)(struct in_addr in);
 struct passwd *(* _getpwuid)(uid_t uid);
+int (*_pam_get_item)(const pam_handle_t *pamh, int item_type, const void **item);
 
 void modify_gecos(const char *username, struct passwd *pass);
-
-static void
-_fatal(const char *msg)
-{
-	perror(msg);
-	exit(1);
-}
-
-static void
-_preload_init(void)
-{
-	void *libc;
-
-#ifndef DL_LAZY
-# define DL_LAZY RTLD_LAZY
-#endif
-	if (!(libc = dlopen(_PATH_LIBC, DL_LAZY))) {
-		_fatal("couldn't dlopen " _PATH_LIBC);
-	} else if (!(_sys_open = dlsym(libc, "open"))) {
-		_fatal("couldn't dlsym 'open'");
-#ifdef HAVE_OPEN64
-	} else if (!(_sys_open = dlsym(libc, "open64"))) {
-		_fatal("couldn't dlsym 'open64'");
-#endif
-	} else if (!(_sys_fopen = dlsym(libc, "fopen"))) {
-		_fatal("couldn't dlsym 'fopen'");
-#ifdef HAVE_FOPEN64
-	} else if (!(_sys_fopen64 = dlsym(libc, "fopen64"))) {
-		_fatal("couldn't dlsym 'fopen64'");
-#endif
-	}
-}
-
-const char *
-_replace(const char *filename)
-{
-	if (strncmp(filename, "/etc/pam.d/", 10) == 0 ||
-            strcmp(filename, "/etc/pam.conf") == 0) {
-		return (getenv("PAM_CONF"));
-	}
-	return (filename);
-}
 
 int
 _isfallback(void)
 {
         char *t = getenv("FALLBACK");
         return (t ? atoi(t) : 0);
-}
-
-int
-open(const char *filename, int flags, ...)
-{
-	return ((*_sys_open)(_replace(filename), flags));
-}
-
-int
-open64(const char *filename, int flags, ...)
-{
-	return ((*_sys_open64)(_replace(filename), flags));
-}
-
-FILE *
-fopen(const char *filename, const char *mode)
-{
-	return ((*_sys_fopen)(_replace(filename), mode));
-}
-
-FILE *
-fopen64(const char *filename, const char *mode)
-{
-	return ((*_sys_fopen64)(_replace(filename), mode));
 }
 
 char *
@@ -177,4 +120,16 @@ getpwnam(const char *name)
     ret.pw_name = username;
 
     return &ret;
+}
+
+int pam_get_item(const pam_handle_t *pamh, int item_type, const void **item) {
+    if(item_type == PAM_SERVICE) {
+        char *s = getenv("SIMULATE_SERVICE");
+        if(s) {
+            *item = s;
+            return PAM_SUCCESS;
+        }
+    }
+    _pam_get_item  = dlsym(RTLD_NEXT, "pam_get_item");
+    return (*_pam_get_item)(pamh, item_type, item);
 }


### PR DESCRIPTION
Some newer PAM stacks segfault when we wrap `open` (and it's variations) in the way we were previously doing. This works around this by doing a (slightly) higher level hack to wrap `pam_get_item` and by installing a real (though temporary) PAM module during PAM testing.
