### PR TITLE
Modified version of PR #215

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 /libtool
 /login_duo/login_duo
 /stamp-h1
+/tests/sigpipe
 /tests/testpam
 Makefile
 Makefile.in

--- a/lib/https.c
+++ b/lib/https.c
@@ -64,6 +64,9 @@ struct https_request {
 
     http_parser *parser;
     int done;
+
+    int sigpipe_ignored;
+    struct sigaction old_sigpipe;
 };
 
 static int
@@ -466,8 +469,6 @@ https_init(const char *cafile, const char *http_proxy)
     ctx.parse_settings.on_body = __on_body;
     ctx.parse_settings.on_message_complete = __on_message_complete;
 
-    signal(SIGPIPE, SIG_IGN);
-
     return (0);
 }
 
@@ -479,6 +480,7 @@ https_open(struct https_request **reqp, const char *host, const char *useragent)
     char *p;
     int n;
     int connection_error = 0;
+    struct sigaction sigpipe;
 
     const char *api_host;
     const char *api_port;
@@ -491,6 +493,13 @@ https_open(struct https_request **reqp, const char *host, const char *useragent)
         https_close(&req);
         return (HTTPS_ERR_SYSTEM);
     }
+
+    memset(&sigpipe, 0, sizeof(sigpipe));
+    sigpipe.sa_handler = SIG_IGN;
+    if (sigaction(SIGPIPE, &sigpipe, &req->old_sigpipe) == 0) {
+      req->sigpipe_ignored = 1;
+    }
+
     if ((p = strchr(req->host, ':')) != NULL) {
         *p = '\0';
         req->port = p + 1;
@@ -772,6 +781,9 @@ https_close(struct https_request **reqp)
         }
         if (req->cbio != NULL) {
             BIO_free_all(req->cbio);
+        }
+        if (req->sigpipe_ignored) {
+          sigaction(SIGPIPE, &req->old_sigpipe, NULL);
         }
         free(req->parser);
         free(req->host);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,6 +11,8 @@ check_LTLIBRARIES += liblogin_duo_preload.la
 liblogin_duo_preload_la_SOURCES = login_duo_preload.c
 liblogin_duo_preload_la_LDFLAGS = -no-undefined -avoid-version -rpath /baz -shared
 
+check_PROGRAMS = sigpipe
+
 if PAM
 TESTS += $(PAM_TESTS)
 
@@ -18,7 +20,7 @@ check_LTLIBRARIES += libtestpam_preload.la
 libtestpam_preload_la_SOURCES = testpam_preload.c
 libtestpam_preload_la_LDFLAGS = -no-undefined -avoid-version -rpath /bar -shared
 
-check_PROGRAMS = testpam
+check_PROGRAMS += testpam
 testpam_LDADD = -lpam
 endif
 

--- a/tests/sigpipe.c
+++ b/tests/sigpipe.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <unistd.h>
+#include <signal.h>
+
+#include <sys/wait.h>
+
+void usage(int argc, char *argv[]) {
+    fprintf(stderr, "usage: %s (run argv... | test)\n", argc ? argv[0] : "sigpipe");
+    exit(2);
+}
+
+int main(int argc, char *argv[]) {
+    pid_t pid;
+    int status;
+
+    if (argc < 2) {
+        usage(argc, argv);
+    }
+
+    if (strcmp(argv[1], "run") == 0) {
+        if (argc < 3) {
+            fprintf(stderr, "error: no program provided\n");
+            usage(argc, argv);
+        }
+        signal(SIGPIPE, SIG_DFL);
+        execvp(argv[2], argv + 2);
+        perror("execvp");
+        exit(1);
+    } else if (strcmp(argv[1], "test") == 0) {
+        if ((pid = fork()) < 0) {
+            perror("fork");
+            exit(1);
+        } else if (pid == 0) {
+            raise(SIGPIPE);
+        } else if (wait(&status) < 0) {
+            perror("wait");
+            exit(1);
+        } else if (WIFSIGNALED(status) && WTERMSIG(status) == SIGPIPE) {
+            printf("Success!\n");
+            exit(0);
+        } else {
+            printf("Failure\n");
+            exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Updated version of #215 which has the following changes
* Different exit codes OSs assign to programs that don't explicitly exit. I had to add exit lines for the "Success" and "Failure" cases of sigpipe.c
* The paths to binaries and tests change when make distcheck is run rather than make check in order to get both passing I had to modify how the path to sigpipe was constructed during the tests.
* I had to update these changes to use Python 3 compatible syntax since we've updated since this was posted.
