### PR TITLE
Add more up-front logging to Duo Unix

### DIFF
--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -423,6 +423,8 @@ main(int argc, char *argv[])
     int c, stat;
     pid_t wait_res;
 
+    duo_syslog(LOG_INFO, "starting Duo Unix: Login Duo");
+
     memset(ctx, 0, sizeof(ctx));
 
     while ((c = getopt(argc, argv, "vc:df:h:?")) != -1) {

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -5,6 +5,7 @@
  * All rights reserved, all wrongs reversed.
  */
 
+#include <sys/syslog.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -124,6 +125,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 
     int i, flags, pam_err, matched;
 
+    duo_syslog(LOG_INFO, "starting Duo Unix: PAM Duo");
     duo_config_default(&cfg);
 
     /* Parse configuration */


### PR DESCRIPTION
In order to more easily establish whether or not Duo Unix is being run an informational message is logged at the beginning of execution.

