### PR TITLE
Fix compiling on AIX with different include priorities

### DIFF
--- a/autotools/ax_check_openssl.m4
+++ b/autotools/ax_check_openssl.m4
@@ -80,7 +80,11 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
         for ssldir in $ssldirs; do
             AC_MSG_CHECKING([for openssl/ssl.h in $ssldir])
             if test -f "$ssldir/include/openssl/ssl.h"; then
-                OPENSSL_INCLUDES="-I$ssldir/include"
+                if test "x$IS_AIX" = "xyes"; then
+                    CFLAGS="$CFLAGS -isystem $ssldir/include"
+                else
+                    OPENSSL_INCLUDES="-I$ssldir/include"
+                fi
                 OPENSSL_LDFLAGS="-L$ssldir/lib"
                 OPENSSL_LIBS="-lssl -lcrypto"
                 found=true


### PR DESCRIPTION
This changes the way that the openssl headers are included on AIX in order to give them higher priority than the compiler's include directory for various reasons. There's a chance this doesn't work for AIX before 7.2 but as those are EoL I think we should adopt this change regardless.

