### PR TITLE
chore: Fix CONTRIBUTING.md terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Once you are ready to make a pull request
 1. Check your style matches our [style guidelines](#style-guidelines).
 2. Make sure you have included tests to cover your change. Check out our[README.md](README.md) for information about our tests.
 3. Follow the instructions in the pull request template.
-4. Make sure that your diff passes the TravisCI tests.
+4. Make sure that your pr passes the TravisCI tests.
 
 ## Style Guidelines
 Our C programming style guidelines are a work in progress right now.


### PR DESCRIPTION
## Summary of the change
Change CONTRIBUTING.md to reference GitHub PR instead of diffs. This is a test PR, do not merge!

## Issue number being addressed
N/A

## Test Plan
N/A

