### PR TITLE
Add better solaris support to support script

### DIFF
--- a/duo_unix_support/duo_unix_support.sh
+++ b/duo_unix_support/duo_unix_support.sh
@@ -113,7 +113,7 @@ else
 fi
 
 if [ "$OS" = "solaris" ]; then
-    if type ggrep >/dev/null; then
+    if type ggrep &>/dev/null; then
         GREP=ggrep
     fi
 else
@@ -127,11 +127,11 @@ echo "openssl_version=${OPENSSL_VER}" >> configuration.txt
 echo "ssh=$(ssh -V 2>&1)" &>> configuration.txt
 echo -e "\nGathering logs and pam configs"
 # Check if the user has gcc and make
-if type gcc >/dev/null; then
+if type gcc &>/dev/null; then
    GCC_VER=$(gcc --version)
    echo "gcc=$GCC_VER" | $GREP "gcc" >> configuration.txt
 fi
-if type make >/dev/null; then
+if type make &>/dev/null; then
    MAKE_VER=$(make --version)
    echo "make=$MAKE_VER" | $GREP "make" >> configuration.txt
 fi


### PR DESCRIPTION
## Issue number being addressed
In order to better support solaris and rarer PAM configurations
we should collect a few additional files with the support script.

## Summary of the change
We now detect which version of `grep` to use based on the OS
and then use `grep` to identify relevant files inside of a user's
/etc/pam.d directory when the support tool is run.

Additionally we now get a copy of authentication logs in /var/adm
which is used on solaris.

## Test Plan
Manually tested on Solaris
