### PR TITLE
Add build date from git and dont add debug info by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ __pycache__/
 Vagrantfile
 .isort.cfg
 .vagrant/
+build-date

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@
 #
 
 ACLOCAL_AMFLAGS = -I autotools
+SOURCE_DATE_EPOCH=$(shell cat $(builddir)/build-date)
 
 SUBDIRS = compat lib login_duo duo_unix_support
 
@@ -18,7 +19,7 @@ endif
 SUBDIRS += tests
 SUBDIRS += tests/unity_tests
 
-dist_doc_DATA = README.md CONTRIBUTING.md AUTHORS CHANGES $(wildcard sbom.spdx)
+dist_doc_DATA = README.md CONTRIBUTING.md AUTHORS CHANGES $(wildcard $(builddir)/build-date) $(wildcard sbom.spdx)
 
 LICENSES = $(wildcard LICENSES/*.txt)
 
@@ -30,3 +31,5 @@ DISTCHECK_CONFIGURE_FLAGS = --sysconfdir='$${prefix}/etc/duo'
 if PAM
 DISTCHECK_CONFIGURE_FLAGS += --with-pam='$${prefix}/lib/security'
 endif
+
+DISTCLEANFILES = $(builddir)/build-date

--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,36 @@ AC_PROG_INSTALL
 AC_PROG_MKDIR_P
 LT_INIT
 
+AC_MSG_NOTICE(checking if we can establish a build date)
+AC_PATH_TOOL(GIT,[git])
+AS_IF([test x"$GIT" != x], [
+    AC_MSG_CHECKING(are we configuring inside a git repository)
+    $GIT rev-parse 2>/dev/null
+    is_git_repo=$?
+    AS_IF([test $is_git_repo == 0], [
+       AC_MSG_RESULT(yes)
+       AC_MSG_CHECKING(is the current working tree clean)
+       $GIT update-index --really-refresh
+       $GIT diff-index --quiet HEAD
+       AS_IF([test $? == 0],
+           [
+               AC_MSG_RESULT(yes)
+               source_date_epoch=`$GIT show -s --format=%ct`
+               AC_MSG_NOTICE(setting build-date to $source_date_epoch)
+               echo "$source_date_epoch" > build-date
+           ],
+           [
+               AC_MSG_RESULT(no current working tree is dirty)
+               AC_MSG_NOTICE(removing build-date)
+               rm -f build-date
+           ]
+       )
+    ],
+    [
+       AC_MSG_RESULT(no)
+    ])
+])
+
 # Set third party library versions
 unity_version=Unity-2.5.2
 AC_DEFINE_DIR([UNITY_VERSION], [unity_version], [Unity directory name])
@@ -124,6 +154,20 @@ AS_IF([test "x$with_coverage" != "xno"], [
    CFLAGS="$CFLAGS -O0 --coverage"
    LFLAGS="$LFLAGS -lgcov --coverage"
    AC_MSG_NOTICE([--coverage enabled in CFLAGS])
+])
+
+AC_ARG_WITH(debug,
+  AS_HELP_STRING([--with-debug=DBG],[build with debug info]),
+  [],
+  [ with_debug=no ]
+)
+AM_CONDITIONAL([DEBUG], [ test "x$with_debug" != "xno" ])
+AS_IF([test "x$with_debug" != "xno"], [
+   CFLAGS="$CFLAGS -g2"
+   AC_MSG_NOTICE([debugging enabled in CFLAGS])
+])
+AS_IF([test "x$with_debug" == "xno"], [
+   CFLAGS="$CFLAGS -g0"
 ])
 
 # Check PAM


### PR DESCRIPTION
## Issue number being addressed
It will help us identify unmodified binaries if our build process results in reproducable binaries
for a given environment.

## Summary of the change
This diff accomplishes that by
1. Removing debugging information by default (compiling with -g0)
2. Attempting to establish a build date from the current commit if the working directory is clean

## Test Plan
Manually tested. Automated testing of this behavior is probably a good idea since there are
enough different cases here but that will have to happen in the apps-testing repo if this PR is adopted.
