### PR TITLE
SELINUX: Add squid_port_t to the policy tunables

### DIFF
--- a/pam_duo/authlogin_duo.te
+++ b/pam_duo/authlogin_duo.te
@@ -27,14 +27,15 @@ gen_require(`
     type http_cache_port_t;
     type http_port_t;
     type local_login_t;
+    type squid_port_t;
     type sshd_t;
     class tcp_socket name_connect;
     ')
 
 tunable_policy(`pam_duo_permit_sshd',`
-    allow sshd_t {http_port_t http_cache_port_t}:tcp_socket name_connect;
+    allow sshd_t {http_port_t http_cache_port_t squid_port_t}:tcp_socket name_connect;
 ')
 
 tunable_policy(`pam_duo_permit_local_login',`
-    allow local_login_t {http_port_t http_cache_port_t}:tcp_socket name_connect;
+    allow local_login_t {http_port_t http_cache_port_t squid_port_t}:tcp_socket name_connect;
 ')


### PR DESCRIPTION
As Squid is a popular Forward Proxy platform, and security binaries should be compiled by trusted partners, add use of squid_port_t to the supplied SELINUX policy object.

Satisfies Issue #162

## Issue number being addressed
Fixes #162

## Summary of the change
Adds `squid_port_t` to the list of ports allowed by the SELINUX policy tunables `pam_duo_permit_sshd` and `pam_duo_permit_local_login`.

## Test Plan
Should be no different from current testing of forward proxies. We have internally validated this change at the University of Maine System.

