### PR TITLE
Disable compiler optimizations on AIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,8 @@ case "$host_os" in
         ;;
     *aix*)
         AC_MSG_NOTICE([-fstack-protector disabled on AIX])
-        CFLAGS="$CFLAGS -Wl,-lm"
+        AC_MSG_NOTICE([Compiler optimizations disabled on AIX])
+        CFLAGS="$CFLAGS -O0 -Wl,-lm"
         has_stack_protector=no
         IS_AIX=yes
         ;;


### PR DESCRIPTION
## Summary of the change
We have seen some Duo Unix crashes on recent versions of AIX related to compiler optimization levels.
This change disables optimizations for AIX which allows for Duo Unix to work correctly.

## Test Plan
Manually tested on AIX 7.2
