### PR TITLE
Change how sysconfdir is used to be more inline with how systems expect

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ licensedir = $(datadir)/LICENSES
 dist_license_DATA = $(LICENSES)
 
 # XXX - get around our default non-prefix-preserving paths for distcheck
-DISTCHECK_CONFIGURE_FLAGS = --sysconfdir='$${prefix}/etc/duo'
+DISTCHECK_CONFIGURE_FLAGS = --sysconfdir='$${prefix}/etc'
 if PAM
 DISTCHECK_CONFIGURE_FLAGS += --with-pam='$${prefix}/lib/security'
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -24,8 +24,8 @@ AB_INIT
 # Init header
 AC_CONFIG_HEADER(config.h)
 
-# Default sysconfdir to /etc/duo
-test "$sysconfdir" = '${prefix}/etc' && sysconfdir=/etc/duo
+# Default sysconfdir to /etc
+test "$sysconfdir" = '${prefix}/etc' && sysconfdir=/etc
 AC_DEFINE_DIR([DUO_CONF_DIR], [sysconfdir], [Configuration directory])
 
 # Determine platform

--- a/login_duo/Makefile.am
+++ b/login_duo/Makefile.am
@@ -21,15 +21,15 @@ install-exec-hook:
 	 chmod 4755 $(DESTDIR)$(sbindir)/login_duo
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
-	-@if [ ! -f $(DESTDIR)$(sysconfdir)/login_duo.conf ]; then \
-	  cp login_duo.conf $(DESTDIR)$(sysconfdir)/login_duo.conf; \
-	  echo "Created ${DESTDIR}$(sysconfdir)/login_duo.conf"; \
+	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/duo
+	-@if [ ! -f $(DESTDIR)$(sysconfdir)/duo/login_duo.conf ]; then \
+	  cp login_duo.conf $(DESTDIR)$(sysconfdir)/duo/login_duo.conf; \
+	  echo "Created ${DESTDIR}$(sysconfdir)/duo/login_duo.conf"; \
 	  echo "Please edit it to add your Duo integration and secret keys"; \
 	else \
-	  echo "Found existing ${DESTDIR}$(sysconfdir)/login_duo.conf - updating permissions"; \
+	  echo "Found existing ${DESTDIR}$(sysconfdir)/duo/login_duo.conf - updating permissions"; \
 	fi
-	-chown $(DUO_PRIVSEP_USER) $(DESTDIR)$(sysconfdir)/login_duo.conf
-	-chmod 600 $(DESTDIR)$(sysconfdir)/login_duo.conf
+	-chown $(DUO_PRIVSEP_USER) $(DESTDIR)$(sysconfdir)/duo/login_duo.conf
+	-chmod 600 $(DESTDIR)$(sysconfdir)/duo/login_duo.conf
 
 EXTRA_DIST = login_duo.conf

--- a/pam_duo/Makefile.am
+++ b/pam_duo/Makefile.am
@@ -50,15 +50,15 @@ clean-local-semodule:
 
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
-	-@if [ ! -f $(DESTDIR)$(sysconfdir)/pam_duo.conf ]; then \
-		cp pam_duo.conf $(DESTDIR)$(sysconfdir)/pam_duo.conf; \
-		echo "Created ${DESTDIR}$(sysconfdir)/pam_duo.conf"; \
+	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/duo
+	-@if [ ! -f $(DESTDIR)$(sysconfdir)/duo/pam_duo.conf ]; then \
+		cp pam_duo.conf $(DESTDIR)$(sysconfdir)/duo/pam_duo.conf; \
+		echo "Created ${DESTDIR}$(sysconfdir)/duo/pam_duo.conf"; \
 		echo "Please edit it to add your Duo integration and secret keys"; \
 	else \
-		echo "Found existing ${DESTDIR}$(sysconfdir)/pam_duo.conf - updating permissions"; \
+		echo "Found existing ${DESTDIR}$(sysconfdir)/duo/pam_duo.conf - updating permissions"; \
 	fi
-	-chmod 600 $(DESTDIR)$(sysconfdir)/pam_duo.conf
+	-chmod 600 $(DESTDIR)$(sysconfdir)/duo/pam_duo.conf
 	-@if test "x$(IS_AIX)" = "xyes"; then \
 		rm -f $(PAMDIR)/pam_duo.so; \
 		ar x $(top_builddir)/pam_duo/.libs/pam_duo.a $(PAMDIR)/pam_duo.so; \


### PR DESCRIPTION
## Issue number being addressed
On Fedora-based systems `/usr/share/config.site` messes with the way that we install configuration
files for duo. Currently we modify `sysconfdir` at configuration time in order to point to `/etc/duo`.
I think we should rather let `sysconfdir` remain as an indicator of the system configuration directory
(e.g `/etc`) and add subdirectories as necessary.

## Summary of the change
`sysconfdir` now points to `${prefix}/etc` instead of `${prefix}/etc/duo`.

## Test Plan
This change has been manually tested on a current Ubuntu and Fedora machine.
