### PR TITLE
Use HMAC_Init_ex() instead of the deprecated HMAC_Init()

### DIFF
--- a/lib/https.c
+++ b/lib/https.c
@@ -696,7 +696,7 @@ https_send(struct https_request *req, const char *method, const char *uri,
         ctx.errstr = strerror(errno);
         return (HTTPS_ERR_LIB);
     }
-    HMAC_Init(hmac, skey, strlen(skey), EVP_sha512());
+    HMAC_Init_ex(hmac, skey, strlen(skey), EVP_sha512(), NULL);
     HMAC_Update(hmac, (unsigned char *)p, strlen(p));
     HMAC_Final(hmac, MD, NULL);
     HMAC_CTX_free(hmac);


### PR DESCRIPTION
LibreSSL will be removing the deprecated HMAC_Init() function in an upcoming release so switch to HMAC_Init_ex() instead.

## Summary of the change
Commit message says it all. We (OpenBSD) have already applied this patch locally in our login_duo port without issue.
