### PR TITLE
Fix a bug in the configure file where a config path setting was missed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@ AC_CONFIG_HEADER(config.h)
 
 # Default sysconfdir to /etc
 test "$sysconfdir" = '${prefix}/etc' && sysconfdir=/etc
-AC_DEFINE_DIR([DUO_CONF_DIR], [sysconfdir], [Configuration directory])
+AC_DEFINE_DIR([DUO_CONF_DIR], [sysconfdir/duo], [Configuration directory])
 
 # Determine platform
 AC_CANONICAL_HOST


### PR DESCRIPTION
## Issue number being addressed
N/A

## Summary of the change
Fixes a spot that was missed in https://github.com/duosecurity/duo_unix/pull/272

## Test Plan
Cloned, built, installed in a clean docker container.
Before:
```
> login_duo
Couldn't open /etc/login_duo.conf: No such file or directory
```
After:
duo_login works as expected
