### PR TITLE
Move to recommended Python approach to wrapping socket to work with p…

### DIFF
--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -282,7 +282,9 @@ def main():
 
     httpd = HTTPServerV6((host, port), MockDuoHandler)
 
-    httpd.socket = ssl.wrap_socket(httpd.socket, certfile=cafile, server_side=True)
+    ctx = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(cafile)
+    httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
 
     httpd.serve_forever()
 


### PR DESCRIPTION
…ython 3.12


## Summary of the change
Moves the ssl socket wrapping to the new approach recommended by python; the way it is done right now was deprecated since 3.7 and has been removed in 3.12

## Test Plan
Successfully ran tests on docker images as far back as python 3.8
