### PR TITLE
Support `quiet` Flag in `pam.d` Config

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -24,6 +24,7 @@
 #include "groupaccess.h"
 
 int duo_debug = 0;
+int duo_quiet = 0;
 
 void
 duo_config_default(struct duo_config *cfg)

--- a/lib/util.h
+++ b/lib/util.h
@@ -18,6 +18,7 @@
 #include <stdarg.h>
 
 extern int duo_debug;
+extern int duo_quiet;
 
 enum {
     DUO_FAIL_SAFE = 0,

--- a/pam_duo/pam_duo.8
+++ b/pam_duo/pam_duo.8
@@ -21,6 +21,9 @@ Specify an alternate configuration file to load. Default is
 .It debug
 Debug mode; send log messages to stderr instead of syslog.
 .El
+.It quiet
+Quiet mode; don't print success/failure messages.
+.El
 .Sh CONFIGURATION
 The INI-format configuration file must have a
 .Dq Li duo

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -88,7 +88,9 @@ __ini_handler(void *u, const char *section, const char *name, const char *val)
 static void
 __duo_status(void *arg, const char *msg)
 {
-    pam_info((pam_handle_t *)arg, "%s", msg);
+    if (!duo_quiet) {
+        pam_info((pam_handle_t *)arg, "%s", msg);
+    }
 }
 
 static char *

--- a/pam_duo/pam_duo_private.c
+++ b/pam_duo/pam_duo_private.c
@@ -19,6 +19,9 @@ parse_argv(const char **config, int argc, const char *argv[])
         } else if (strcmp("debug", argv[i]) == 0) {
             /* duo_debug is a global variable defined in util.h */
             duo_debug = 1;
+        } else if (strcmp("quiet", argv[i]) == 0) {
+            /* duo_quiet is a global variable defined in util.h */
+            duo_quiet = 1;
         } else {
             duo_syslog(LOG_ERR, "Invalid pam_duo option: '%s'",
                 argv[i]);

--- a/pam_duo/pam_duo_private.h
+++ b/pam_duo/pam_duo_private.h
@@ -11,6 +11,6 @@
 #include <string.h>
 #include "util.h"
 
-/* Parses argv to get the configuration file location and the debug mode */
+/* Parses argv to get the configuration file location and the debug/quiet modes */
 int
 parse_argv(const char **config, int argc, const char *argv[]);

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -241,6 +241,20 @@ class TestPamPrompts(unittest.TestCase):
 
 
 @unittest.skipIf(sys.platform == "sunos5", SOLARIS_ISSUE)
+class TestPamQuiet(unittest.TestCase):
+    def run(self, result=None):
+        with MockDuo(NORMAL_CERT):
+            return super(TestPamQuiet, self).run(result)
+
+    def test_quiet(self):
+        with TempConfig(MOCKDUO_PROMPTS_1) as temp:
+            result = pam_duo(["-d", "-f", "pam_prompt", "-c", temp.name, "-q", "true"])
+            self.assertRegex(result["stderr"][0], "Failed Duo login for 'pam_prompt'")
+            self.assertEqual(len(result["stdout"]), 1)
+            self.assertRegex(result["stdout"][0], "^$")
+
+
+@unittest.skipIf(sys.platform == "sunos5", SOLARIS_ISSUE)
 class TestPamEnv(CommonSuites.Env):
     def call_binary(self, *args, **kwargs):
         return pam_duo(*args, **kwargs)
@@ -315,6 +329,21 @@ class TestPamdConf(unittest.TestCase):
                     ["-d", "-c", duo_config.name, "-f", "whatever"], pam_config.name
                 )
                 self.assertEqual(process.returncode, 1)
+
+
+@unittest.skipIf(sys.platform == "sunos5", SOLARIS_ISSUE)
+class TestPamdConfQuiet(unittest.TestCase):
+    def test_quiet_argument(self):
+        with TempConfig(MOCKDUO_CONF) as duo_config:
+            pamd_conf = "auth  required  {libpath}/pam_duo.so conf={duo_config_path} quiet".format(
+                libpath=os.path.join(topbuilddir, "pam_duo", ".libs"),
+                duo_config_path=duo_config.name,
+            )
+            with TempPamConfig(pamd_conf) as pam_config:
+                process = testpam(
+                    ["-d", "-c", duo_config.name, "-f", "whatever"], pam_config.name
+                )
+                self.assertEqual(process.returncode, 0)
 
 
 @unittest.skipIf(sys.platform == "sunos5", SOLARIS_ISSUE)

--- a/tests/testpam.py
+++ b/tests/testpam.py
@@ -79,13 +79,14 @@ def testpam(args, config_file_name, env_overrides=None):
 
 def main():
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "dc:f:h:")
+        opts, args = getopt.getopt(sys.argv[1:], "dqc:f:h:")
     except getopt.GetoptError:
         usage()
 
     opt_conf = "/etc/duo/pam_duo.conf"
     opt_user = getpass.getuser()
     opt_host = None
+    opt_quiet = False
 
     for o, a in opts:
         if o == "-c":
@@ -94,6 +95,8 @@ def main():
             opt_user = a
         elif o == "-h":
             opt_host = a
+        elif o == "-q":
+            opt_quiet = True
 
     args = [opt_user]
     if opt_host:
@@ -102,6 +105,8 @@ def main():
     config = "auth  required  {libpath}/pam_duo.so conf={duo_config_path} debug".format(
         libpath=paths.topbuilddir + "/pam_duo/.libs", duo_config_path=opt_conf
     )
+    if opt_quiet:
+        config = config + " quiet"
     with TempPamConfig(config) as config_file:
         process = testpam(args, config_file.name)
 


### PR DESCRIPTION
Example:
**`/etc/pam.d/ssh`**
```
auth   sufficient   pam_duo.so quiet
```

## Summary of the change
A trivial update that allows admins to silence `pam_info()` messages

## Test Plan
I added two simple tests:
1. Make sure the `pam.d` parser accepts the `quiet` flag
2. Make sure passing the `quiet` flag actually *does* silence the output  «grin»

PS: I also added the flag to the `pam_duo(8)` manpage.