### PR TITLE
Fixed multiple memory related issues in duo_common_ini_handler

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -62,6 +62,8 @@ int duo_common_ini_handler(
 /* Clean up config memory. */
 void close_config(struct duo_config *cfg);
 
+void cleanup_config_groups(struct duo_config *cfg);
+
 int duo_check_groups(struct passwd *pw, char **groups, int groups_cnt);
 
 void duo_log(


### PR DESCRIPTION
## Summary of the change
Addressed multiple memory-related issues within the duo_common_ini_handler function. The changes include:
* Fixed memory leaks by ensuring proper deallocation of resources.
* Resolved buffer overflows by implementing safer memory handling practices.

## Test Plan
Run `valgrind --leak-check=full login_duo/login_duo` using the `login_duo.conf` file with at least one of the groups containing escaped whitespace.
