### PR TITLE
Removed 'NULL' string option from testutil_duo_split_at

### DIFF
--- a/lib/testutil_duo_split_at.c
+++ b/lib/testutil_duo_split_at.c
@@ -28,7 +28,7 @@ int failure()
 int main (int argc, char *argv[])
 {
     if (argc != 5) {
-        printf("Format: %s <string|NULL> <delimiter> <position> <expected|NULL>\n", argv[0]);
+        printf("Format: %s <string> <delimiter> <position> <expected|NULL>\n", argv[0]);
         return EXIT_FAILURE;
     }
 
@@ -36,10 +36,6 @@ int main (int argc, char *argv[])
     char *delimiter = argv[2];
     int position = atoi(argv[3]);
     char *expected = argv[4];
-
-    if (strcmp(s, "NULL") == 0) {
-        s = NULL;
-    }
 
     char *result = duo_split_at(s, *delimiter, position);
 


### PR DESCRIPTION
## Summary of the change
Removed the 'NULL' string option from `testutil_duo_split_at` to avoid potential Segmentation Faults when 'NULL' is passed as an input string. This option is never used as an input parameter in our codebase, so its removal does not impact current functionality but eliminates the risk of future issues.

## Test Plan
Ran the test suite to ensure no existing functionality was affected by this change.
