### PR TITLE
Mark Coverity check issue as intentional with code annotation

### DIFF
--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -43,9 +43,11 @@ if sys.platform == "sunos5":
     # Solaris timesout filedescriptors rather than issuing an EOF but
     # still uses EOF to signal a user prompt
     EOF = pexpect.TIMEOUT
+    # coverity[copy_paste_error,remediation]
     PROMPT = pexpect.EOF
 else:
     EOF = pexpect.EOF
+    # coverity[original]
     PROMPT = pexpect.EOF
 
 def fips_available():

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -28,6 +28,7 @@ import urllib
 import urllib.parse
 
 IKEY = "DIXYZV6YM8IFYVWBINCA"
+# coverity[assign]
 SKEY = b"yWHSMhWucAcp7qvuH3HWTaSaKABs8Gaddiv1NIRo"
 # Used to check if the FQDN is set to either the ipv4 or ipv6 address
 IPV6_LOOPBACK_ADDR = (
@@ -54,10 +55,12 @@ tx_msgs = {
 }
 
 
+# coverity[sink]
 class MockDuoHandler(BaseHTTPRequestHandler):
     server_version = "MockDuo/1.0"
     protocol_version = "HTTP/1.1"
 
+    # coverity[sink]
     def _verify_sig(self):
         authz = base64.b64decode(self.headers["Authorization"].split()[1]).decode(
             "utf-8"
@@ -81,6 +84,7 @@ class MockDuoHandler(BaseHTTPRequestHandler):
                 )
             )
         canon.append("&".join(l))
+        # coverity[pass,credentials_use,remediation]
         h = hmac.new(SKEY, ("\n".join(canon)).encode("utf8"), digestmod="sha512")
 
         return sig == h.hexdigest()


### PR DESCRIPTION
## Summary of the change

This PR marks a Coverity check in the mockduo.py test file as intentional (hardcoded credentials) and suppresses another Coverity check in common_suites.py.

## Test Plan
N/A