### PR TITLE
Print configuration path on load

### DIFF
--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -142,6 +142,8 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     config = ctx->config ? ctx->config : DUO_CONF;
     flags = 0;
 
+    duo_syslog(LOG_INFO, "Loading config file %s\n", config);
+
     duo_config_default(&cfg);
 
     /* Load our private config. */

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -142,7 +142,7 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     config = ctx->config ? ctx->config : DUO_CONF;
     flags = 0;
 
-    duo_syslog(LOG_INFO, "Loading config file %s\n", config);
+    duo_syslog(LOG_INFO, "Loading config file %s", config);
 
     duo_config_default(&cfg);
 

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -132,6 +132,8 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 
     /* Parse configuration */
     config = DUO_CONF;
+    duo_syslog(LOG_INFO, "Loading config file %s",
+        config);
     if(parse_argv(&config, argc, argv) == 0) {
         return (PAM_SERVICE_ERR);
     }

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -69,15 +69,6 @@ class CommonTestCase(unittest.TestCase):
 
         self.assertTrue(found, f"Regex '{regex}' not found in any lines of {result}")
 
-    def assertSomeline(self, result: list[str], s: str):
-        found = False
-        for line in result:
-            if line == s:
-                found = True
-                break
-
-        self.assertTrue(found, f"Line '{s}' not found in any lines of {result}")
-
     def call_binary(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -587,6 +587,9 @@ class CommonSuites:
 
     class Interactive(CommonTestCase):
         PROMPT_REGEX = ".* or option \\(1-4\\): $"
+        INITIAL_TEXT = [
+            ".*Loading config file .*",
+        ]
         PROMPT_TEXT = [
             "Duo login for foobar",
             "Choose or lose:",
@@ -598,7 +601,7 @@ class CommonSuites:
         ]
 
         def remove_header_lines(self, s):
-            return "\r\n".join(s.split("\r\n")[1:])
+            return s
 
         def assertOutputEqual(self, output, expected):
             processed_output = [line for line in output.split("\r\n") if line != ""]
@@ -629,7 +632,7 @@ class CommonSuites:
                 )
                 self.assertOutputEqual(
                     self.remove_header_lines(process.match.group(0)),
-                    CommonSuites.Interactive.PROMPT_TEXT,
+                    self.INITIAL_TEXT + CommonSuites.Interactive.PROMPT_TEXT,
                 )
                 process.sendline(b"123456")
                 self.assertEqual(
@@ -681,7 +684,7 @@ class CommonSuites:
                 )
                 self.assertOutputEqual(
                     self.remove_header_lines(process.match.group(0)),
-                    CommonSuites.Interactive.PROMPT_TEXT,
+                    self.INITIAL_TEXT + CommonSuites.Interactive.PROMPT_TEXT,
                 )
                 process.sendline(b"3")
                 self.assertEqual(

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -597,11 +597,11 @@ class TestLoginDuoGECOS(CommonTestCase):
                 result = login_duo(
                     ["-d", "-c", temp.name, "true"],
                 )
-                self.assertSomeline(
-                    result["stderr"],
+                self.assertIn(
                     "Invalid gecos_delim '{delim}' (delimiter must be punctuation other than ':')".format(
                         delim=config["gecos_delim"]
                     ),
+                    result["stderr"],
                 )
                 self.assertRegexSomeline(
                     result["stderr"],

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -382,7 +382,7 @@ class TestLoginDuoTimeout(CommonTestCase):
                 preload_script=os.path.join(TESTDIR, "login_duo.py"),
                 timeout=10,
             )
-            for line in result["stderr"][2:5]:
+            for line in result["stderr"][1:4]:
                 self.assertEqual(line, "Attempting connection")
 
             self.assertRegexSomeline(
@@ -617,8 +617,8 @@ class TestLoginDuoGECOS(CommonTestCase):
             result = login_duo(
                 ["-d", "-c", temp.name, "true"],
             )
-            self.assertEqual(
-                result["stderr"][2],
+            self.assertRegexSomeline(
+                result["stderr"],
                 "Invalid character option length. Character fields must be 1 character long: ''",
             )
             self.assertRegexSomeline(
@@ -635,8 +635,8 @@ class TestLoginDuoGECOS(CommonTestCase):
             result = login_duo(
                 ["-d", "-c", temp.name, "true"],
             )
-            self.assertEqual(
-                result["stderr"][2],
+            self.assertRegexSomeline(
+                result["stderr"],
                 "Gecos position starts at 1",
             )
             self.assertRegexSomeline(

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -398,8 +398,8 @@ class TestPamGECOS(CommonTestCase):
                 result = pam_duo(
                     ["-d", "-c", temp.name, "true"],
                 )
-                self.assertEqual(
-                    result["stderr"][1],
+                self.assertRegexSomeline(
+                    result["stderr"],
                     "Invalid gecos_delim '{delim}' (delimiter must be punctuation other than ':')".format(
                         delim=config["gecos_delim"]
                     ),
@@ -419,15 +419,15 @@ class TestPamGECOS(CommonTestCase):
                 ["-d", "-c", temp.name, "true"],
             )
             self.assertEqual(
-                result["stderr"][1],
+                result["stderr"][0],
                 "Invalid character option length. Character fields must be 1 character long: ''",
             )
             self.assertRegex(
-                result["stderr"][2],
+                result["stderr"][1],
                 r"Invalid pam_duo option: 'gecos_delim'",
             )
             self.assertRegex(
-                result["stderr"][3],
+                result["stderr"][2],
                 r"Parse error in {config}, line \d+".format(config=temp.name),
             )
 

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -400,7 +400,7 @@ class TestPamGECOS(CommonTestCase):
                 result = pam_duo(
                     ["-d", "-c", temp.name, "true"],
                 )
-                self.assertSomeline(
+                self.assertIn(
                     result["stderr"],
                     "Invalid gecos_delim '{delim}' (delimiter must be punctuation other than ':')".format(
                         delim=config["gecos_delim"]

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -279,6 +279,8 @@ class TestPamPreauthFailures(CommonSuites.PreauthFailures):
 
 @unittest.skipIf(sys.platform == "sunos5", SOLARIS_ISSUE)
 class TestPamDuoInteractive(CommonSuites.Interactive):
+    INITIAL_TEXT = []
+
     def call_binary(self, *args, **kwargs):
         return pam_duo_interactive(*args, **kwargs)
 

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -401,10 +401,10 @@ class TestPamGECOS(CommonTestCase):
                     ["-d", "-c", temp.name, "true"],
                 )
                 self.assertIn(
-                    result["stderr"],
                     "Invalid gecos_delim '{delim}' (delimiter must be punctuation other than ':')".format(
                         delim=config["gecos_delim"]
                     ),
+                    result["stderr"],
                 )
                 self.assertRegexSomeline(
                     result["stderr"],

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -437,15 +437,15 @@ class TestPamGECOS(CommonTestCase):
                 ["-d", "-c", temp.name, "true"],
             )
             self.assertEqual(
-                result["stderr"][1],
+                result["stderr"][0],
                 "Gecos position starts at 1",
             )
             self.assertRegex(
-                result["stderr"][2],
+                result["stderr"][1],
                 r"Invalid pam_duo option: 'gecos_username_pos'",
             )
             self.assertRegex(
-                result["stderr"][3],
+                result["stderr"][2],
                 r"Parse error in {config}, line \d+".format(config=temp.name),
             )
 

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -400,7 +400,7 @@ class TestPamGECOS(CommonTestCase):
                 result = pam_duo(
                     ["-d", "-c", temp.name, "true"],
                 )
-                self.assertRegexSomeline(
+                self.assertSomeline(
                     result["stderr"],
                     "Invalid gecos_delim '{delim}' (delimiter must be punctuation other than ':')".format(
                         delim=config["gecos_delim"]


### PR DESCRIPTION
## Issue number being addressed

## Summary of the change
Prints the configuration path when Duo Unix is run for support and debugging purposes

## Test Plan
No new tests added for log messages
