### PR TITLE
Add `quiet` option to silence "deny" messages

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -24,6 +24,7 @@
 #include "groupaccess.h"
 
 int duo_debug = 0;
+int duo_quiet = 0;
 
 void
 duo_config_default(struct duo_config *cfg)

--- a/lib/util.h
+++ b/lib/util.h
@@ -18,6 +18,7 @@
 #include <stdarg.h>
 
 extern int duo_debug;
+extern int duo_quiet;
 
 enum {
     DUO_FAIL_SAFE = 0,

--- a/pam_duo/pam_duo.8
+++ b/pam_duo/pam_duo.8
@@ -21,6 +21,9 @@ Specify an alternate configuration file to load. Default is
 .It debug
 Debug mode; send log messages to stderr instead of syslog.
 .El
+.It quiet
+Quiet mode; don't print success/failure messages.
+.El
 .Sh CONFIGURATION
 The INI-format configuration file must have a
 .Dq Li duo

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -88,7 +88,9 @@ __ini_handler(void *u, const char *section, const char *name, const char *val)
 static void
 __duo_status(void *arg, const char *msg)
 {
-    pam_info((pam_handle_t *)arg, "%s", msg);
+    if (!duo_quiet) {
+        pam_info((pam_handle_t *)arg, "%s", msg);
+    }
 }
 
 static char *

--- a/pam_duo/pam_duo_private.c
+++ b/pam_duo/pam_duo_private.c
@@ -19,6 +19,9 @@ parse_argv(const char **config, int argc, const char *argv[])
         } else if (strcmp("debug", argv[i]) == 0) {
             /* duo_debug is a global variable defined in util.h */
             duo_debug = 1;
+        } else if (strcmp("quiet", argv[i]) == 0) {
+            /* duo_quiet is a global variable defined in util.h */
+            duo_quiet = 1;
         } else {
             duo_syslog(LOG_ERR, "Invalid pam_duo option: '%s'",
                 argv[i]);

--- a/pam_duo/pam_duo_private.h
+++ b/pam_duo/pam_duo_private.h
@@ -11,6 +11,6 @@
 #include <string.h>
 #include "util.h"
 
-/* Parses argv to get the configuration file location and the debug mode */
+/* Parses argv to get the configuration file location and the debug/quiet modes */
 int
 parse_argv(const char **config, int argc, const char *argv[]);

--- a/tests/testpam.py
+++ b/tests/testpam.py
@@ -79,13 +79,14 @@ def testpam(args, config_file_name, env_overrides=None):
 
 def main():
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "dc:f:h:")
+        opts, args = getopt.getopt(sys.argv[1:], "dqc:f:h:")
     except getopt.GetoptError:
         usage()
 
     opt_conf = "/etc/duo/pam_duo.conf"
     opt_user = getpass.getuser()
     opt_host = None
+    opt_quiet = False
 
     for o, a in opts:
         if o == "-c":
@@ -94,6 +95,8 @@ def main():
             opt_user = a
         elif o == "-h":
             opt_host = a
+        elif o == "-q":
+            opt_quiet = True
 
     args = [opt_user]
     if opt_host:
@@ -102,6 +105,8 @@ def main():
     config = "auth  required  {libpath}/pam_duo.so conf={duo_config_path} debug".format(
         libpath=paths.topbuilddir + "/pam_duo/.libs", duo_config_path=opt_conf
     )
+    if opt_quiet:
+        config = config + " quiet"
     with TempPamConfig(config) as config_file:
         process = testpam(args, config_file.name)
 


### PR DESCRIPTION
## Summary of the change

Nothing big; it's pretty much just like it says on the tin — allow, e.g., `/etc/pam.d/sshd` to use:
```
auth   sufficient   pam_duo.so quiet
                               ^^^^^ 
```

...and thereby *not* display the failure message back to the user.

## Test Plan

I added `TestPamQuiet` and `TestPamdConfQuiet` unit tests.  (Honestly, the tests account for more of the PR than the actual code change itself!)

PS: And FWIW, I also documented it in the `pam_duo(8)` man page.