### PR TITLE
Ignore the cppcheck finding regarding __xx__ in pam_extra

### DIFF
--- a/.false_positive.txt
+++ b/.false_positive.txt
@@ -3,3 +3,4 @@
 *:compat/asprintf.c:63
 *:lib/https.c:492
 *:lib/https.c:503
+*:pam_duo/pam_extra.c:92


### PR DESCRIPTION
## Summary of the change
Get CI passing again by ignoring a cppcheck find.
The variable in question is being initialized on the next line.

## Test Plan
CI should pass
