### PR TITLE
Use Sequence type to play nicer with older Pythons

### DIFF
--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -39,6 +39,8 @@ from config import (
 )
 from mockduo_context import NORMAL_CERT, SELFSIGNED_CERT, WRONGHOST_CERT, MockDuo
 
+from typing import Sequence
+
 TESTDIR = os.path.realpath(os.path.dirname(__file__))
 
 if sys.platform == "sunos5":
@@ -60,7 +62,7 @@ def fips_available():
 
 
 class CommonTestCase(unittest.TestCase):
-    def assertRegexSomeline(self, result: list[str], regex: str):
+    def assertRegexSomeline(self, result: Sequence[str], regex: str):
         found = False
         for line in result:
             if re.search(regex, line):


### PR DESCRIPTION
## Issue number being addressed
Fixes #

## Summary of the change
Replace `list` type with `Sequence` to work better with some older Python versions

## Test Plan
locally tested on Python 3.8 (Ubuntu 20)
