### PR TITLE
Fix build under FreeBSD + OpenSSL deprecation warnings

### DIFF
--- a/lib/https.c
+++ b/lib/https.c
@@ -235,7 +235,7 @@ _SSL_check_server_cert(SSL *ssl, const char *hostname)
         for (i = 0; i < n && match != 1; i++) {
             const GENERAL_NAME *altname = sk_GENERAL_NAME_value(altnames, i);
             if (hostnametype == altname->type) {
-                char *altptr = (char *)ASN1_STRING_data(altname->d.ia5);
+                char *altptr = (char *)ASN1_STRING_get0_data(altname->d.ia5);
                 size_t altsize = (size_t)ASN1_STRING_length(altname->d.ia5);
 
                 if (altname->type == GEN_DNS) {
@@ -262,7 +262,7 @@ _SSL_check_server_cert(SSL *ssl, const char *hostname)
             if ((tmp = X509_NAME_ENTRY_get_data(
                        X509_NAME_get_entry(subject, i))) != NULL &&
                 ASN1_STRING_type(tmp) == V_ASN1_UTF8STRING) {
-                const char *pattern = (char *)ASN1_STRING_data(tmp);
+                const char *pattern = (char *)ASN1_STRING_get0_data(tmp);
                 size_t patternsize = (size_t)ASN1_STRING_length(tmp);
                 if (patternsize == strlen(pattern)) {
                     if (!strchr(pattern, '*')) {


### PR DESCRIPTION
## Fixes
* Add missing header under FreeBSD
* Fix use of deprecated OpenSSL function

## Build Log (Errors)

```
--- https.lo ---
https.c:208:21: error: variable has incomplete type 'struct in6_addr'
  208 |     struct in6_addr addr;
      |                     ^
https.c:208:12: note: forward declaration of 'struct in6_addr'
  208 |     struct in6_addr addr;
      |            ^
https.c:220:20: error: invalid application of 'sizeof' to an incomplete type 'struct in6_addr'
  220 |         addrsize = sizeof(struct in6_addr);
      |                    ^     ~~~~~~~~~~~~~~~~~
https.c:208:12: note: forward declaration of 'struct in6_addr'
  208 |     struct in6_addr addr;
      |            ^
```

```
--- https.lo ---
https.c:238:40: warning: 'ASN1_STRING_data' is deprecated [-Wdeprecated-declarations]
  238 |                 char *altptr = (char *)ASN1_STRING_data(altname->d.ia5);
      |                                        ^
/usr/include/openssl/asn1.h:554:1: note: 'ASN1_STRING_data' has been explicitly marked deprecated here
  554 | DEPRECATEDIN_1_1_0(unsigned char *ASN1_STRING_data(ASN1_STRING *x))
      | ^
/usr/include/openssl/opensslconf.h:154:34: note: expanded from macro 'DEPRECATEDIN_1_1_0'
  154 | # define DEPRECATEDIN_1_1_0(f)   DECLARE_DEPRECATED(f)
      |                                  ^
/usr/include/openssl/opensslconf.h:112:55: note: expanded from macro 'DECLARE_DEPRECATED'
  112 | #   define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
      |                                                       ^
https.c:265:47: warning: 'ASN1_STRING_data' is deprecated [-Wdeprecated-declarations]
  265 |                 const char *pattern = (char *)ASN1_STRING_data(tmp);
      |                                               ^
/usr/include/openssl/asn1.h:554:1: note: 'ASN1_STRING_data' has been explicitly marked deprecated here
  554 | DEPRECATEDIN_1_1_0(unsigned char *ASN1_STRING_data(ASN1_STRING *x))
      | ^
/usr/include/openssl/opensslconf.h:154:34: note: expanded from macro 'DEPRECATEDIN_1_1_0'
  154 | # define DEPRECATEDIN_1_1_0(f)   DECLARE_DEPRECATED(f)
      |                                  ^
/usr/include/openssl/opensslconf.h:112:55: note: expanded from macro 'DECLARE_DEPRECATED'
  112 | #   define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
      |                                                       ^
https.c:841:5: warning: 'HMAC_Init' is deprecated [-Wdeprecated-declarations]
  841 |     HMAC_Init(hmac, skey, strlen(skey), EVP_sha512());
      |     ^
/usr/include/openssl/hmac.h:30:1: note: 'HMAC_Init' has been explicitly marked deprecated here
   30 | DEPRECATEDIN_1_1_0(__owur int HMAC_Init(HMAC_CTX *ctx, const void *key, int len,
      | ^
/usr/include/openssl/opensslconf.h:154:34: note: expanded from macro 'DEPRECATEDIN_1_1_0'
  154 | # define DEPRECATEDIN_1_1_0(f)   DECLARE_DEPRECATED(f)
      |                                  ^
/usr/include/openssl/opensslconf.h:112:55: note: expanded from macro 'DECLARE_DEPRECATED'
  112 | #   define DECLARE_DEPRECATED(f)    f __attribute__ ((deprecated));
      |        
```
