### PR TITLE
Fix 404 link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ We use [SemVer](http://semver.org/) for versioning.
 
 ## License
 
-This project is licensed under the GPLv2 License - see the [LICENSE](LICENSE) file for details
+This project is licensed under the GPLv2 License - see the [LICENSE](LICENSES/GPL-2.0-with-classpath-exception.txt) file for details
 
 ## Support
 


### PR DESCRIPTION
Point to the license file correctly

## Issue number being addressed
Fixes #328 

## Summary of the change
Fix LICENSE link to point to the GPLv2 license file

## Test Plan
N/A
