### PR TITLE
Fix enrollment URL display in interactive mode

### DIFF
--- a/lib/duo.c
+++ b/lib/duo.c
@@ -491,8 +491,18 @@ _duo_preauth(struct duo_ctx *ctx, const char *username,
         }
         ret = DUO_ABORT;
     } else if (strcasecmp(result, "enroll") == 0) {
+        /* For enrollment, check if prompt.text exists and use it instead of status_msg */
+        const char *enrollment_msg = output; // default to status_msg
+        JSON_Object *prompt_obj = json_object_get_object(response, "prompt");
+        if (prompt_obj != NULL) {
+            const char *prompt_text = json_object_get_string(prompt_obj, "text");
+            if (prompt_text != NULL) {
+                enrollment_msg = prompt_text;
+            }
+        }
+
         if (ctx->conv_status != NULL) {
-            ctx->conv_status(ctx->conv_arg, output);
+            ctx->conv_status(ctx->conv_arg, enrollment_msg);
         }
         _duo_seterr(ctx, "User enrollment required");
         ret = DUO_ABORT;

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -781,6 +781,19 @@ class CommonSuites:
                     0,
                 )
 
+        def test_enrollment_shows_url(self):
+            """Test that enrollment URL is displayed in interactive mode - reproduces issue #336"""
+            with TempConfig(MOCKDUO_CONF) as temp:
+                process = self.call_binary(
+                    ["-d", "-c", temp.name, "-f", "enroll", "true"],
+                )
+                self.assertEqual(
+                    process.expect(r"https://.*?/portal", timeout=5),
+                    0,
+                )
+                # The process should terminate
+                self.assertEqual(process.expect(EOF), 0)
+
     class InvalidBSON(CommonTestCase):
         def run(self, result=None):
             with MockDuo(NORMAL_CERT):

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -305,7 +305,15 @@ class MockDuoHandler(BaseHTTPRequestHandler):
             elif self.args["username"] == "gecos/6":
                 ret["response"] = {"result": "allow", "status_msg": "gecos/6"}
             elif self.args["username"] == "enroll":
-                ret["response"] = {"result": "enroll", "status_msg": "please enroll"}
+                ret["response"] = {
+                    "enroll_portal_url": "https://api-abcd1234.duosecurity.com/portal?code=48bac5d9393fb2c2&akey=DIXXXXXXXXXXXXXXXXXX",
+                    "result": "enroll",
+                    "status_msg": "Enroll an authentication device to proceed"
+                }
+                if self.args["text_prompt"]:
+                    ret["response"]["prompt"] = {
+                        "text": "Please enroll at https://api-abcd1234.duosecurity.com/portal?code=48bac5d9393fb2c2&akey=DIXXXXXXXXXXXXXXXXXX"
+                    }
             elif self.args["username"] == "bad-json":
                 buf = b""
             elif self.args["username"] == "retry-after-3-preauth-allow":


### PR DESCRIPTION
## Issue number being addressed
Fixes #336 

## Summary of the change
When enrollment is required, display the enrollment URL from prompt.text
instead of just the generic status message. This provides users with
the actual URL they need to complete enrollment.

## Test Plan
Updated unit tests accordingly

