### PR TITLE
pam_duo: Log all invalid options before failing

### DIFF
--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -123,7 +123,8 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
      * without.
      */
     duopam_const char *ip, *service, *user;
-    const char *cmd, *p, *config, *host;
+    const char *cmd, *p, *host;
+    const char *config = DUO_CONF;
 
     int i, flags, pam_err, matched;
 
@@ -131,9 +132,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
     duo_config_default(&cfg);
 
     /* Parse configuration */
-    config = DUO_CONF;
-    duo_syslog(LOG_INFO, "Loading config file %s",
-        config);
+    duo_syslog(LOG_INFO, "Loading config file %s", config);
     if(parse_argv(&config, argc, argv) == 0) {
         return (PAM_SERVICE_ERR);
     }

--- a/pam_duo/pam_duo_private.c
+++ b/pam_duo/pam_duo_private.c
@@ -13,17 +13,17 @@ int
 parse_argv(const char **config, int argc, const char *argv[])
 {
     int i;
+    int valid = 1;
     for (i = 0; i < argc; i++) {
-        if ((strncmp("conf=", argv[i], 5) == 0) && (*config != NULL)) {
+        if (strncmp("conf=", argv[i], 5) == 0) {
             *config = argv[i] + 5;
         } else if (strcmp("debug", argv[i]) == 0) {
             /* duo_debug is a global variable defined in util.h */
             duo_debug = 1;
         } else {
-            duo_syslog(LOG_ERR, "Invalid pam_duo option: '%s'",
-                argv[i]);
-            return 0; 
+            duo_syslog(LOG_ERR, "Invalid pam_duo option: '%s'", argv[i]);
+            valid = 0;
         }
     }
-    return 1;
+    return valid;
 }

--- a/tests/unity_tests/pam_argv_parse_test.c
+++ b/tests/unity_tests/pam_argv_parse_test.c
@@ -16,14 +16,6 @@
 extern void setUp(void) {};
 extern void tearDown(void) {};
 
-static void test_pam_config_NULL() {
-    const char *config = NULL;
-    const char *argv[] = {"conf=hi"};
-    int argc = 1;
-
-    TEST_ASSERT_FALSE(parse_argv(&config, argc, argv));
-}
-
 static void test_pam_argc_zero() {
     const char *config = "";
     const char *argv[] = {NULL};
@@ -66,7 +58,6 @@ static void test_pam_argv_conf() {
 
 int main() {
     UNITY_BEGIN();
-    RUN_TEST(test_pam_config_NULL);
     RUN_TEST(test_pam_argc_zero);
     RUN_TEST(test_pam_argv_error);
     RUN_TEST(test_pam_argv_debug);


### PR DESCRIPTION
## Summary of the change
 - Log all invalid options before failing in parse_argv
 - Removed invalid check in parse_argv
 - Added and removed corresponding unit tests

## Test Plan
Unit tests
