### PR TITLE
Fix timegm conflicting types error on AIX

### DIFF
--- a/acconfig.h
+++ b/acconfig.h
@@ -35,6 +35,7 @@ size_t strnlen(const char *str, size_t maxlen);
 #endif
 
 #ifndef HAVE_TIMEGM
+#include <time.h>
 
 time_t timegm(struct tm *tm);
 #endif


### PR DESCRIPTION
## Summary
- Include `<time.h>` before declaring the `timegm` fallback prototype in `acconfig.h`
- Without this include, `struct tm` is an incomplete type local to the function declaration
- When `config.h` is included multiple times (from `pam_duo.c:12` and again via `pam_extra.h:9`), each inclusion creates a different incomplete `struct tm` type, causing "conflicting types for 'timegm'" compilation errors

This follows the same pattern as other compat functions in `acconfig.h` (e.g., `asprintf` includes `<stdarg.h>`, `getgrouplist` includes `<grp.h>`).

Fixes #356

## Test plan
- [x] Build on AIX 7.3 with OpenSSL 3.0 (customer environment that reported the issue)
- [ ] Verify existing CI tests pass