### PR TITLE
https: Add missing netinet/in.h include for FreeBSD portability

### DIFF
--- a/lib/https.c
+++ b/lib/https.c
@@ -9,9 +9,10 @@
 
 #include "config.h"
 
-#include <arpa/inet.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <sys/time.h>
 
 #include <netdb.h>


### PR DESCRIPTION
## Summary
- Fixes compilation failure on some FreeBSD systems where `struct in6_addr` is not defined
- Adds explicit `#include <netinet/in.h>` to `lib/https.c`, matching other source files in the project

## Problem
Some FreeBSD configurations don't transitively include `<netinet/in.h>` via `<arpa/inet.h>`, causing:
```
https.c:208:21: error: storage size of 'addr' isn't known
https.c:220:27: error: invalid application of 'sizeof' to incomplete type 'struct in6_addr'
```

## Test plan
- [ ] Verify compilation on FreeBSD
- [ ] Verify compilation on Linux (no regression)