### PR TITLE
Support script: add Solaris auth log paths and fix grep fallback

### DIFF
--- a/duo_unix_support/README.md
+++ b/duo_unix_support/README.md
@@ -7,6 +7,8 @@ Logs
     /var/log/messages
     /var/log/auth.log
     /var/log/syslog
+    /var/adm/authlog
+    /var/log/authlog
 
 Configs
     /etc/duo/login_duo.conf

--- a/duo_unix_support/duo_unix_support.sh
+++ b/duo_unix_support/duo_unix_support.sh
@@ -34,7 +34,7 @@ while true; do
     shift
 done
 
-echo -e "The Duo Unix support script gathers and aggregates information about your Duo Unix installation and the server it is installed on for easy sending to Duo Security support. This script is intended to be used with Debian, Ubuntu, RHEL, and CentOS systems. While use of this script is not required for support cases with Duo, it is highly recommended as it will expedite the support and debugging process. Namely, this script collects:\n\n\t* Logfiles in /var/log, such as auth and secure\n\t* PAM configurations in /etc/pam.d, such as common-auth or sshd\n\t* SSHD configurations in /etc/ssh\n\t* Information about the server distribution and relevant libraries such as SELinux or OpenSSL\n\t* Configurations for pam_duo and login_duo scrubbed of sensitive skeys\n\nThese files are typically asked for during support cases with Duo. We advise that you review any of these files prior to running this script should you wish to expunge any other information you deem sensitive from these files. For a full list of the information collected by this script, see ${README_INSTALL}/share/doc/duo_unix/duo_unix_support/README.md."
+echo -e "The Duo Unix support script gathers and aggregates information about your Duo Unix installation and the server it is installed on for easy sending to Duo Security support. This script is intended to be used with Debian, Ubuntu, RHEL, and CentOS systems. While use of this script is not required for support cases with Duo, it is highly recommended as it will expedite the support and debugging process. Namely, this script collects:\n\n\t* Logfiles such as auth.log, secure, and authlog from /var/log and /var/adm\n\t* PAM configurations in /etc/pam.d, such as common-auth or sshd\n\t* SSHD configurations in /etc/ssh\n\t* Information about the server distribution and relevant libraries such as SELinux or OpenSSL\n\t* Configurations for pam_duo and login_duo scrubbed of sensitive skeys\n\nThese files are typically asked for during support cases with Duo. We advise that you review any of these files prior to running this script should you wish to expunge any other information you deem sensitive from these files. For a full list of the information collected by this script, see ${README_INSTALL}/share/doc/duo_unix/duo_unix_support/README.md."
 
 read -rp "Do you wish to run this program? [N/y] " user_input
 
@@ -112,10 +112,8 @@ else
     echo "Could not find version of Duo Unix (login_duo was not found)" > configuration.txt
 fi
 
-if [ "$OS" = "solaris" ]; then
-    if type ggrep &>/dev/null; then
-        GREP=ggrep
-    fi
+if type ggrep >/dev/null 2>&1; then
+    GREP=ggrep
 else
     GREP=grep
 fi
@@ -186,6 +184,9 @@ COPY_FILES=(
            "/var/log/syslog"
            "/var/adm/messages"
            "/var/adm/messages.0"
+           # Solaris auth log paths
+           "/var/adm/authlog"
+           "/var/log/authlog"
 )
 
 PAM_DUO_FILES=$($GREP -ilr "pam_duo.so" "/etc/pam.d")


### PR DESCRIPTION
## Summary of the change
Add /var/adm/authlog and /var/log/authlog to collected log files for Solaris systems where auth logs are routed to these paths. Fix $GREP variable so it is always set — previously if ggrep was not installed on Solaris, $GREP was never assigned, causing downstream grep calls to fail.

## Test Plan
N/A

