### PR TITLE
Add openssl3_scanner.sh for deprecated low-level OpenSSL API detection

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -33,4 +33,4 @@ check_PROGRAMS += testpam
 testpam_LDADD = -lpam
 endif
 
-EXTRA_DIST = certs confs cram.py fips_scanner.sh groups.py login_duo.py mockduo.py mocklogin_duo.py paths.py testpam.py $(TESTS) $(PAM_TESTS) common_suites.py mockduo_context.py config.py
+EXTRA_DIST = certs confs cram.py fips_scanner.sh openssl3_scanner.sh groups.py login_duo.py mockduo.py mocklogin_duo.py paths.py testpam.py $(TESTS) $(PAM_TESTS) common_suites.py mockduo_context.py config.py

--- a/tests/openssl3_scanner.sh
+++ b/tests/openssl3_scanner.sh
@@ -5,20 +5,22 @@
 # Copyright (c) 2023 Cisco Systems, Inc. and/or its affiliates
 # All rights reserved.
 #
-# fips_scanner.sh
+# openssl3_scanner.sh
 #
-# This program scans for low-level Openssl function calls that are NOT
-# allowed when running in FIPS mode. The list of functions was taken
-# from searching the Openssl library for calls to "fips_cipher_abort" and
-# "fips_md_init_ctx" which are the functions for generating the low-level
-# API abort messages.  These abort messages are only generated when running
-# in FIPS mode. We then looked at the ".h" for each cipher/digest and manpage to
-# get the list of related low-level function calls.
+# This program scans for low-level OpenSSL function calls that are
+# deprecated in OpenSSL 3.x.  These functions bypass the EVP abstraction
+# layer and should be replaced with their EVP equivalents.  The lists
+# below were taken from the same source as fips_scanner.sh (searching
+# the OpenSSL library for low-level cipher and digest APIs).
+#
+# This scanner is separated from fips_scanner.sh so that OpenSSL 3.x
+# deprecation concerns are tracked independently from FIPS 140-3
+# compliance concerns.
 #
 # Usage:
-#   ./fips_scanner.sh <directory to scan>
+#   ./openssl3_scanner.sh <directory to scan>
 #
-# If no directory is given, it scans the directory the current directory.
+# If no directory is given, it scans the current directory.
 #
 #
 case "$OSTYPE" in
@@ -136,20 +138,21 @@ echo -e "===================================\n"
 
 EXITCODE=0
 
-#Exclude files that are being used to search for anything not fips compliant 
+#Exclude files that are being used to search for anything not compliant
 #Unless excluded, these files will also be scanned and trigger false positives
-errorFile="fips_scanner.sh.err"
+errorFile="openssl3_scanner.sh.err"
+openssl3Scanner="openssl3_scanner.sh"
 fipsScanner="fips_scanner.sh"
-opensslScanner="openssl3_scanner.sh"
 testCrypto="test_crypto-0*"
 for cipher in ${CIPHER_LIST[@]} ; do
-    if $GREP -R ${cipher} ${DIR} --exclude={$fipsScanner,$opensslScanner,$testCrypto,$errorFile} ; then
+    echo "Scanning for cipher function: ${cipher}"
+    if $GREP -R ${cipher} ${DIR} --exclude={$openssl3Scanner,$fipsScanner,$testCrypto,$errorFile} ; then
       echo "Found potential calls for ${cipher}"
       EXITCODE=1
     fi
 done
 
-# Scan for unapproved digest calls
+# Scan for deprecated low-level digest calls
 DIGEST_LIST=("SHA1_Init"
              "SHA1_Update"
              "SHA1_Final"
@@ -169,10 +172,11 @@ DIGEST_LIST=("SHA1_Init"
 echo -e "\nChecking for low-level digest calls"
 echo -e "===================================\n"
 for digest in ${DIGEST_LIST[@]} ; do
-    if $GREP -R ${digest} ${DIR} --exclude={$fipsScanner,$opensslScanner,$testCrypto,$errorFile} ; then
+    echo "Scanning for digest function: ${digest}"
+    if $GREP -R ${digest} ${DIR} --exclude={$openssl3Scanner,$fipsScanner,$testCrypto,$errorFile} ; then
       echo "Found potential calls for ${digest}"
       EXITCODE=1
-    fi    
+    fi
 done
 
 exit $EXITCODE

--- a/tests/test_crypto-0.t
+++ b/tests/test_crypto-0.t
@@ -120,3 +120,125 @@ Testing files to make sure fips compliant
   Scanning for cipher function: SHA512_Update
   Scanning for cipher function: SHA512_Final
 
+Testing files for deprecated low-level OpenSSL 3.x APIs
+  $ cd ${TESTDIR}
+  $ ./openssl3_scanner.sh ../
+  Starting scan ...
+  Scanning directory
+
+  Checking for low-level cipher calls
+  ===================================
+
+  Scanning for cipher function: AES_set_encrypt_key
+  Scanning for cipher function: AES_set_decrypt_key
+  Scanning for cipher function: AES_encrypt
+  Scanning for cipher function: AES_decrypt
+  Scanning for cipher function: AES_ctr128_encrypt
+  Scanning for cipher function: AES_ecb_encrypt
+  Scanning for cipher function: AES_cbc_encrypt
+  Scanning for cipher function: AES_cfb128_encrypt
+  Scanning for cipher function: AES_cfb1_encrypt
+  Scanning for cipher function: AES_cfb8_encrypt
+  Scanning for cipher function: AES_ofb128_encrypt
+  Scanning for cipher function: AES_ctr128_encrypt
+  Scanning for cipher function: AES_ige_encrypt
+  Scanning for cipher function: AES_bi_ige_encrypt
+  Scanning for cipher function: AES_wrap_key
+  Scanning for cipher function: AES_unwrap_key
+  Scanning for cipher function: BF_set_key
+  Scanning for cipher function: BF_encrypt
+  Scanning for cipher function: BF_ecb_encrypt
+  Scanning for cipher function: BF_cbc_encrypt
+  Scanning for cipher function: BF_cfb64_encrypt
+  Scanning for cipher function: BF_ofb64_encrypt
+  Scanning for cipher function: Camellia_set_key
+  Scanning for cipher function: Camellia_encrypt
+  Scanning for cipher function: Camellia_decrypt
+  Scanning for cipher function: Camellia_ecb_encrypt
+  Scanning for cipher function: Camellia_cbc_encrypt
+  Scanning for cipher function: Camellia_cfb128_encrypt
+  Scanning for cipher function: Camellia_cfb1_encrypt
+  Scanning for cipher function: Camellia_cfb8_encrypt
+  Scanning for cipher function: Camellia_ofb128_encrypt
+  Scanning for cipher function: Camellia_ctr128_encrypt
+  Scanning for cipher function: CAST_set_key
+  Scanning for cipher function: CAST_ecb_encrypt
+  Scanning for cipher function: CAST_encrypt
+  Scanning for cipher function: CAST_cbc_encrypt
+  Scanning for cipher function: CAST_cfb64_encrypt
+  Scanning for cipher function: CAST_ofb64_encrypt
+  Scanning for cipher function: DES_set_key_unchecked
+  Scanning for cipher function: DES_ecb2_encrypt
+  Scanning for cipher function: DES_ede2_cbc_encrypt
+  Scanning for cipher function: DES_ede2_cfb64_encrypt
+  Scanning for cipher function: DES_ede2_ofb64_encrypt
+  Scanning for cipher function: DES_ecb3_encrypt
+  Scanning for cipher function: DES_cbc_cksum
+  Scanning for cipher function: DES_cbc_encrypt
+  Scanning for cipher function: DES_ncbc_encrypt
+  Scanning for cipher function: DES_xcbc_encrypt
+  Scanning for cipher function: DES_cfb_encrypt
+  Scanning for cipher function: DES_ecb_encrypt
+  Scanning for cipher function: DES_encrypt1
+  Scanning for cipher function: DES_encrypt2
+  Scanning for cipher function: DES_encrypt3
+  Scanning for cipher function: DES_decrypt3
+  Scanning for cipher function: DES_ede3_cbc_encrypt
+  Scanning for cipher function: DES_ede3_cbcm_encrypt
+  Scanning for cipher function: DES_ede3_cfb64_encrypt
+  Scanning for cipher function: DES_ede3_cfb_encrypt
+  Scanning for cipher function: DES_ede3_ofb64_encrypt
+  Scanning for cipher function: DES_enc_read
+  Scanning for cipher function: DES_enc_write
+  Scanning for cipher function: DES_ofb_encrypt
+  Scanning for cipher function: DES_quad_cksum
+  Scanning for cipher function: DES_random_key
+  Scanning for cipher function: DES_check_key_parity
+  Scanning for cipher function: DES_set_key
+  Scanning for cipher function: DES_pcbc_encrypt
+  Scanning for cipher function: DES_set_key_checked
+  Scanning for cipher function: DES_string_to_key
+  Scanning for cipher function: DES_cfb64_encrypt
+  Scanning for cipher function: DES_ofb64_encrypt
+  Scanning for cipher function: DES_read_password
+  Scanning for cipher function: DES_fixup_key_parity
+  Scanning for cipher function: DES_set_odd_parity
+  Scanning for cipher function: idea_set_encrypt_key
+  Scanning for cipher function: idea_ecb_encrypt
+  Scanning for cipher function: idea_set_decrypt_key
+  Scanning for cipher function: idea_cfb64_encrypt
+  Scanning for cipher function: idea_ofb64_encrypt
+  Scanning for cipher function: idea_encrypt
+  Scanning for cipher function: RC2_set_key
+  Scanning for cipher function: RC2_encrypt
+  Scanning for cipher function: RC2_cbc_encrypt
+  Scanning for cipher function: RC2_cfb64_encrypt
+  Scanning for cipher function: RC2_ofb64_encrypt
+  Scanning for cipher function: RC4_set_key
+  Scanning for cipher function: SEED_set_key
+  Scanning for cipher function: SEED_encrypt
+  Scanning for cipher function: SEED_decrypt
+  Scanning for cipher function: SEED_ecb_encrypt
+  Scanning for cipher function: SEED_cbc_encrypt
+  Scanning for cipher function: SEED_cfb128_encrypt
+  Scanning for cipher function: SEED_ofb128_encrypt
+
+  Checking for low-level digest calls
+  ===================================
+
+  Scanning for digest function: SHA1_Init
+  Scanning for digest function: SHA1_Update
+  Scanning for digest function: SHA1_Final
+  Scanning for digest function: SHA224_Init
+  Scanning for digest function: SHA224_Update
+  Scanning for digest function: SHA224_Final
+  Scanning for digest function: SHA256_Init
+  Scanning for digest function: SHA256_Update
+  Scanning for digest function: SHA256_Final
+  Scanning for digest function: SHA384_Init
+  Scanning for digest function: SHA384_Update
+  Scanning for digest function: SHA384_Final
+  Scanning for digest function: SHA512_Init
+  Scanning for digest function: SHA512_Update
+  Scanning for digest function: SHA512_Final
+

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -31,6 +31,19 @@ class TestCrypto(unittest.TestCase):
             ),
         )
 
+    def test_openssl3_deprecated_apis(self):
+        process = subprocess.Popen(
+            [os.path.join(TESTDIR, "openssl3_scanner.sh")], stdout=subprocess.PIPE
+        )
+        (stdout, stderr) = process.communicate()
+        self.assertEqual(
+            process.returncode,
+            0,
+            "ERROR: Found deprecated low-level OpenSSL API calls:\n{stdout}".format(
+                stdout=stdout
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary of the change
New scanner script that checks for low-level OpenSSL APIs (AES_encrypt, SHA512_Init, etc.) that bypass the EVP layer and are deprecated in OpenSSL 3.x. These checks are split from fips_scanner.sh to separate deprecation concerns from FIPS 140-3 compliance concerns.

Also updates fips_scanner.sh exclusion list to skip openssl3_scanner.sh (prevents false positives from scanning the new script's array contents).

## Test Plan
Tests should pass
