### PR TITLE
Remove RAND_load_file DRBG bypass, fix FIPS compliance

### DIFF
--- a/lib/https.c
+++ b/lib/https.c
@@ -690,14 +690,9 @@ https_init(const char *cafile, const char *http_proxy)
     SSL_load_error_strings();
     OpenSSL_add_all_algorithms();
 
-    /* XXX - ape openssl s_client -rand for testing on ancient systems */
     if (!RAND_status()) {
-        if ((p = getenv("RANDFILE")) != NULL) {
-            RAND_load_file(p, 8192);
-        } else {
-            ctx.errstr = "No /dev/random, EGD, or $RANDFILE";
-            return (HTTPS_ERR_LIB);
-        }
+        ctx.errstr = "PRNG not seeded: system has no entropy source";
+        return (HTTPS_ERR_LIB);
     }
     if ((ctx.ssl_ctx = SSL_CTX_new(SSLv23_client_method())) == NULL) {
         ctx.errstr = _SSL_strerror();

--- a/tests/fips_scanner.sh
+++ b/tests/fips_scanner.sh
@@ -20,10 +20,6 @@
 # is an OpenSSL 3.x deprecation concern and is checked separately by
 # openssl3_scanner.sh.
 #
-# Known finding: RAND_load_file in lib/https.c (DRBG bypass).  This is
-# an AIX fallback for systems without /dev/random and cannot be removed
-# without breaking those platforms.  Those systems cannot run in FIPS mode
-# anyway (no kernel entropy source), so this is not a real-world FIPS risk.
 #
 # Usage:
 #   ./fips_scanner.sh <directory to scan>

--- a/tests/test_crypto-0.t
+++ b/tests/test_crypto-0.t
@@ -54,8 +54,6 @@ Testing files to make sure fips compliant
   =================================
 
   Scanning for function: RAND_load_file
-  ../lib/https.c:            RAND_load_file(p, 8192);
-  Found potential calls for RAND_load_file
   Scanning for function: RAND_seed
   Scanning for function: RAND_add
 
@@ -64,7 +62,6 @@ Testing files to make sure fips compliant
 
   Scanning for function: FIPS_mode_set
   Scanning for function: FIPS_mode_get
-  [1]
 
 Testing files for deprecated low-level OpenSSL 3.x APIs
   $ cd ${TESTDIR}

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -19,8 +19,6 @@ TESTDIR = os.path.realpath(os.path.dirname(__file__))
 
 class TestCrypto(unittest.TestCase):
     def test_fips_scanner(self):
-        # Known finding: RAND_load_file in lib/https.c (DRBG bypass).
-        # Change expected returncode to 0 once that is resolved.
         process = subprocess.Popen(
             [os.path.join(TESTDIR, "fips_scanner.sh"), os.path.join(TESTDIR, "..")],
             stdout=subprocess.PIPE,
@@ -28,9 +26,8 @@ class TestCrypto(unittest.TestCase):
         (stdout, stderr) = process.communicate()
         self.assertEqual(
             process.returncode,
-            1,
-            "Expected fips_scanner to find RAND_load_file (known issue), "
-            "but it returned {rc}:\n{stdout}".format(
+            0,
+            "ERROR: Found FIPS-non-compliant patterns:\n{stdout}".format(
                 rc=process.returncode, stdout=stdout
             ),
         )


### PR DESCRIPTION
## Summary

- Remove the `RAND_load_file($RANDFILE)` fallback from `lib/https.c` and replace with a fail-closed `RAND_status()` check
- Remove the "known finding" comment from `tests/fips_scanner.sh` (scanner now passes clean for DRBG bypass category)

## Motivation

**FIPS compliance:** `RAND_load_file` is not FIPS-compliant under OpenSSL 3's FIPS provider. It bypasses the DRBG's approved seeding mechanism by injecting arbitrary file bytes as trusted entropy, violating NIST SP-800-90Ar1.

**Dead code:** The `$RANDFILE` fallback was a workaround for systems lacking `/dev/urandom`. The last such platform (AIX 5.1) went end-of-support in April 2006. Every supported Unix (AIX 5.2+, Solaris 9+, FreeBSD 4.2+, all Linux, all BSDs) has had kernel-based entropy for 20+ years, making this code path unreachable.

**Security (issue #277):** The return value of `RAND_load_file` was never checked. If the file was empty or unreadable, the code proceeded with a potentially unseeded PRNG. The new code fails closed instead.

## What changes

```c
// Before: attempt RANDFILE workaround, proceed even if it fails
if (!RAND_status()) {
    if ((p = getenv("RANDFILE")) != NULL) {
        RAND_load_file(p, 8192);  // return value unchecked
    } else {
        ctx.errstr = "No /dev/random, EGD, or $RANDFILE";
        return (HTTPS_ERR_LIB);
    }
}

// After: fail closed
if (!RAND_status()) {
    ctx.errstr = "PRNG not seeded: system has no entropy source";
    return (HTTPS_ERR_LIB);
}
```

## Risk

Extremely low. `RAND_status()` returns 1 immediately on any system with `/dev/urandom`, which is every supported OS. The removed code path was unreachable in practice. On the theoretical system where `RAND_status()` returns 0, we now fail explicitly rather than silently proceeding with weak entropy.

## Test plan

- [x] `tests/fips_scanner.sh` now exits 0 (previously exited 1 due to `RAND_load_file` detection)
- [x] Existing test suite passes (`make check`)
- [ ] Manual: SSH login with pam_duo still works on a standard Linux system

Resolves #277

*This analysis was generated with AI assistance (Claude).*