### PR TITLE
Pin actions/checkout to v4.3.1 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y autoconf libtool libpam-dev libssl-dev automake python3 python3-pip cppcheck
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Build
         run: ./bootstrap && ./configure --with-pam --prefix=/usr && make CC=${{ matrix.cc }}


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from unpinned `v2` tag to `v4.3.1` pinned by full commit SHA (`34e114876b0b11c390a56381ad16ebd13914f8d5`)
- v2 uses deprecated Node 16 which GitHub is removing from runners
- Pinning by SHA prevents tag-substitution supply-chain attacks

## Test plan
- [x] CI workflow triggers and completes successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)