### PR TITLE
Fix locale-dependent strftime breaking HMAC auth

### DIFF
--- a/lib/https.c
+++ b/lib/https.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <locale.h>
 
 #include <openssl/bio.h>
 #include <openssl/err.h>
@@ -929,11 +930,18 @@ https_send(struct https_request *req, const char *method, const char *uri,
     char *qs, *p, date[128];
     int i, n, is_get;
     time_t t;
+    locale_t c_locale;
 
     req->done = 0;
 
     t = time(NULL) + time_offset; /* adjust time by offset */
-    strftime(date, sizeof date, "%a, %d %b %Y %T %z", localtime(&t));
+    c_locale = newlocale(LC_TIME_MASK, "C", (locale_t)0);
+    if (c_locale == (locale_t)0) {
+        ctx.errstr = "Failed to create C locale";
+        return (HTTPS_ERR_LIB);
+    }
+    strftime_l(date, sizeof date, "%a, %d %b %Y %T +0000", gmtime(&t), c_locale);
+    freelocale(c_locale);
 
     /* Generate query string and canonical request to sign */
     if ((qs = _argv_to_qs(argc, argv)) == NULL) {


### PR DESCRIPTION
## Summary

- Replace `strftime(localtime())` with `strftime_l(gmtime())` using an explicit C locale for the `X-Duo-Date` header
- Hardcode `+0000` UTC offset instead of relying on platform-specific `%z` behavior

## Motivation

Three related bugs where `strftime` produces output that breaks HMAC signature verification:

- **#366 / #355**: On systems where the PAM-consuming process (GDM, login, etc.) has called `setlocale(LC_ALL, "")`, pam_duo inherits the locale. `strftime` then produces localized day/month names (e.g., "mar", "juin" instead of "Tue", "Jun"), causing the Duo API to reject the request with HTTP 401.
- **#363**: On AIX, `strftime %z` produces a timezone name ("EST") instead of a numeric offset ("-0500"), also breaking signature verification.

## Fix

```c
// Before: locale-dependent, platform-specific %z
strftime(date, sizeof date, "%a, %d %b %Y %T %z", localtime(&t));

// After: explicit C locale, UTC with fixed offset
locale_t c_locale = newlocale(LC_TIME_MASK, "C", (locale_t)0);
strftime_l(date, sizeof date, "%a, %d %b %Y %T +0000", gmtime(&t), c_locale);
freelocale(c_locale);
```

- `strftime_l` with C locale guarantees English day/month names regardless of process locale
- `gmtime()` with `+0000` sidesteps the AIX `%z` bug entirely
- UTC matches the Python client's default `sig_timezone` behavior

## Platform support

`strftime_l` (POSIX.1-2008) is available on Linux (glibc), macOS, FreeBSD, AIX 7.2+, Solaris 11.4+, and illumos. Not available on Solaris 11.3 and earlier (EOL for premier support: January 2024).

## Test plan

- [x] Verified on Ubuntu 24.04 VM with `LC_ALL=fr_FR.UTF-8`
- [x] Unpatched: pam_duo produces French date header → Duo API returns 401
- [x] Patched: pam_duo produces English UTC date → auth succeeds
- [x] Tested using `test_pam_locale.c` harness that calls `setlocale(LC_ALL, "")` before PAM auth (simulates GDM/display manager behavior)
- [x] Existing test suite passes (`make check`)

Resolves #366, #355, #363

*This analysis was generated with AI assistance (Claude).*