### PR TITLE
Replace hardcoded 8.8.8.8 with RFC 5737 documentation IP

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -293,7 +293,9 @@ duo_local_ip()
 
     memset(&sin, 0, sizeof(sin));
     sin.sin_family = AF_INET;
-    sin.sin_addr.s_addr = inet_addr("8.8.8.8"); /* XXX Google's DNS Server */
+    /* RFC 5737 TEST-NET-1 example IP; no traffic is sent, the kernel
+       only performs a routing table lookup to determine the local IP. */
+    sin.sin_addr.s_addr = inet_addr("192.0.2.1");
     sin.sin_port = htons(53);
     slen = sizeof(sin);
 


### PR DESCRIPTION
## Summary

Replace `8.8.8.8` (Google DNS) with `192.0.2.1` (RFC 5737 TEST-NET-1) in `duo_local_ip()`.

## Context

`duo_local_ip()` uses a well-known trick: create a UDP socket, `connect()` it to a remote IP (which only does a routing table lookup — no packet is sent), then `getsockname()` to learn which local interface would be used. Any routable unicast IP works as the target.

Using `8.8.8.8` causes:
- Security auditors to flag it as an external data leak
- Firewall teams to question why a PAM module references Google DNS
- Confusion about whether DNS queries are being sent

`192.0.2.1` is IANA-reserved (RFC 5737) specifically for documentation and examples — it will never be assigned to a real host, and any network engineer recognizes it as a placeholder.

## Verified

Tested that `connect()` + `getsockname()` returns the correct local IP with `192.0.2.1` as the target (identical behavior to `8.8.8.8`).

Resolves #259

*This analysis was generated with AI assistance (Claude).*