### PR TITLE
Harden CI workflow and update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,18 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y autoconf libtool libpam-dev libssl-dev automake python3 python3-pip cppcheck
 
       - name: Checkout repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build
-        run: ./bootstrap && ./configure --with-pam --prefix=/usr && make CC=${{ matrix.cc }}
+        env:
+          CC: ${{ matrix.cc }}
+        run: ./bootstrap && ./configure --with-pam --prefix=/usr && make
 
       - name: Install test dependencies
         run: pip3 install -r test_requirements.in
 
       - name: Run tests
-        run: sudo make distcheck
+        run: make distcheck
 
       - name: Static analysis
         run: cppcheck --quiet --force -i tests --suppressions-list=.false_positive.txt --error-exitcode=1 .
@@ -42,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run FIPS test suite
         run: ./tests/fips/run_fips_test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: pip3 install -r test_requirements.in
 
       - name: Run tests
-        run: make distcheck
+        run: sudo make distcheck
 
       - name: Static analysis
         run: cppcheck --quiet --force -i tests --suppressions-list=.false_positive.txt --error-exitcode=1 .


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4.3.1 to v6.0.3, pinned to commit SHA for reproducibility
- Pass compiler selection via environment variable instead of direct shell interpolation

## Test plan
- [x] CI passes on both gcc and clang matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)