### PR TITLE
duo_login returns DUO_FAIL if the polling loop exits with no result

### DIFF
--- a/lib/duo.c
+++ b/lib/duo.c
@@ -767,6 +767,10 @@ duo_login(struct duo_ctx *ctx, const char *username,
         }
         _JSON_VALUE_FREE(json_new);
     }
+    if (i == 20) {
+        _duo_seterr(ctx, "Authentication timed out");
+        ret = DUO_FAIL;
+    }
     return (ret);
 }
 

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -717,6 +717,28 @@ class CommonSuites:
             self.menu_options(MOCKDUO_CONF)
             self.menu_success(MOCKDUO_CONF)
 
+        def test_auth_status_loop_exhaustion_denies(self):
+            with TempConfig(MOCKDUO_CONF) as temp:
+                process = self.call_binary(
+                    ["-d", "-c", temp.name, "-f", "foobar", "true"],
+                )
+                self.assertEqual(
+                    process.expect(CommonSuites.Interactive.PROMPT_REGEX, timeout=10), 0
+                )
+                process.sendline(b"longwait")
+                self.assertEqual(
+                    process.expect(CommonSuites.Interactive.PROMPT_REGEX, timeout=5), 0
+                )
+                self.assertOutputEqual(
+                    process.match.group(0),
+                    ["longwait"]
+                    + ["Still waiting..."] * 20
+                    + [
+                        "[4] Failed Duo login for 'foobar': Authentication timed out",
+                    ]
+                    + CommonSuites.Interactive.PROMPT_TEXT,
+                )
+
         def test_autopush_nomenu(self):
             with TempConfig(MOCKDUO_AUTOPUSH) as temp:
                 process = self.call_binary(

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -57,6 +57,7 @@ tx_msgs = {
         "1:Answered. Press '#' on your phone to log in.",
         "2:Authentication timed out.",
     ],
+    "txLONGWAIT": ["0:Still waiting..."] * 21,
 }
 
 


### PR DESCRIPTION
Future-proof the polling loop by explicitly handling a hypothetical case where Duo's API returns more than 20 status messages for a single async auth.