### PR TITLE
Handle unprivileged child process exiting due to a signal

### DIFF
--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -410,7 +410,7 @@ main(int argc, char *argv[])
     struct login_ctx ctx[1];
     struct passwd *pw;
     pid_t pid;
-    int c, stat;
+    int c, stat = 0;
     pid_t wait_res;
 
     duo_syslog(LOG_INFO, "starting Duo Unix: Login Duo");
@@ -458,6 +458,8 @@ main(int argc, char *argv[])
                     strerror(errno));
             }
             exit(do_auth(ctx, get_command(argc, argv)));
+        } else if (pid < 0) {
+            die("fork: %s", strerror(errno));
         } else {
             /* Parent continues as user. */
             if (drop_privs(getuid(), getgid()) != 0) {
@@ -472,8 +474,12 @@ main(int argc, char *argv[])
             if (wait_res != pid) {
                 die("waitpid: %s", strerror(errno));
             }
-            if (WEXITSTATUS(stat) == 0) {
+            if (WIFEXITED(stat) && WEXITSTATUS(stat) == 0) {
                 do_exec(ctx, get_command(argc, argv));
+            }
+            if (WIFSIGNALED(stat)) {
+                die("unprivileged process terminated by signal: %d",
+                    WTERMSIG(stat));
             }
         }
     } else {

--- a/tests/login_duo_preload.c
+++ b/tests/login_duo_preload.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 
 #include <poll.h>
+#include <signal.h>
 
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -31,6 +32,11 @@ int (*_sys_getaddrinfo)(const char *node, const char *service, const struct addr
 char *(*_sys_inet_ntoa)(struct in_addr in);
 struct passwd *(*_getpwnam)(const char* name);
 FILE *(*_fopen)(const char* filename, const char* mode);
+int (*_sys_setgid)(gid_t gid);
+int (*_sys_setuid)(uid_t uid);
+
+static gid_t _mock_gid = (gid_t)-1;
+static uid_t _mock_uid = (uid_t)-1;
 
 static struct passwd _passwd[11] = {
         { "sshd", "*", 1000, 100, .pw_gecos = "gecos", .pw_dir = "/",
@@ -122,7 +128,47 @@ getuid(void)
 {
         char *p = getenv("UID");
 
+        if (_mock_uid != (uid_t)-1) {
+            return (_mock_uid);
+        }
         return (p ? atoi(p) : 1004);
+}
+
+int
+setuid(uid_t uid)
+{
+        if (getenv("MOCK_SETUID")) {
+            char *signal_auth_child = getenv("SIGNAL_AUTH_CHILD");
+            _mock_uid = uid;
+            if (signal_auth_child && uid == 1000) {
+                raise(atoi(signal_auth_child));
+            }
+            return (0);
+        }
+        _sys_setuid = dlsym(RTLD_NEXT, "setuid");
+        return (*_sys_setuid)(uid);
+}
+
+gid_t
+getgid(void)
+{
+        char *p = getenv("GID");
+
+        if (_mock_gid != (gid_t)-1) {
+            return (_mock_gid);
+        }
+        return (p ? atoi(p) : 100);
+}
+
+int
+setgid(gid_t gid)
+{
+        if (getenv("MOCK_SETUID")) {
+            _mock_gid = gid;
+            return (0);
+        }
+        _sys_setgid = dlsym(RTLD_NEXT, "setgid");
+        return (*_sys_setgid)(gid);
 }
 
 uid_t

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -72,7 +72,17 @@ def login_duo_interactive(args, env=None, preload_script=""):
     if env is None:
         env = {}
 
-    excluded_keys = ["SSH_CONNECTION", "FALLBACK", "UID", "http_proxy", "TIMEOUT"]
+    excluded_keys = [
+        "SSH_CONNECTION",
+        "FALLBACK",
+        "UID",
+        "EUID",
+        "GID",
+        "http_proxy",
+        "TIMEOUT",
+        "MOCK_SETUID",
+        "SIGNAL_AUTH_CHILD",
+    ]
     env_passthrough = {
         key: os.environ[key] for key in os.environ if key not in excluded_keys
     }
@@ -107,7 +117,17 @@ def login_duo(args, env=None, timeout=10, preload_script=""):
     else:
         login_duo_path = [os.path.join(BUILDDIR, "login_duo", "login_duo")]
 
-    excluded_keys = ["SSH_CONNECTION", "FALLBACK", "UID", "http_proxy", "TIMEOUT"]
+    excluded_keys = [
+        "SSH_CONNECTION",
+        "FALLBACK",
+        "UID",
+        "EUID",
+        "GID",
+        "http_proxy",
+        "TIMEOUT",
+        "MOCK_SETUID",
+        "SIGNAL_AUTH_CHILD",
+    ]
     env_passthrough = {
         key: os.environ[key] for key in os.environ if key not in excluded_keys
     }
@@ -236,6 +256,26 @@ class TestLoginDuoConfig(CommonTestCase):
         result = login_duo(["-v"])
         self.assertRegexSomeline(result["stderr"], "login_duo \\d+\\.\\d+.\\d+")
 
+
+class TestLoginDuoPrivsep(CommonTestCase):
+    def test_signal_terminated_auth_child_fails_closed(self):
+        """Refuse login if the setuid auth child terminates by signal."""
+        result = login_duo(
+            ["echo", "Success"],
+            env={
+                "UID": "1001",
+                "EUID": "0",
+                "MOCK_SETUID": "1",
+                "SIGNAL_AUTH_CHILD": "15",
+            },
+            preload_script=os.path.join(TESTDIR, "login_duo.py"),
+        )
+
+        self.assertEqual(result["returncode"], 1)
+        self.assertNotIn("Success", result["stdout"])
+        self.assertIn(
+            "unprivileged process terminated by signal: 15",
+            result["stderr"])
 
 class TestLoginDuoEnv(CommonSuites.Env):
     def call_binary(self, *args, **kwargs):


### PR DESCRIPTION
Return specific errors if fork() failed or if the child process exited abnormally due to a signal.