### PR TITLE
Switch duo_unix_support to an allowlist-based conf scrubber

### DIFF
--- a/duo_unix_support/Makefile.am
+++ b/duo_unix_support/Makefile.am
@@ -11,4 +11,6 @@ docdir = $(datadir)/doc/@PACKAGE@/duo_unix_support
 doc_DATA = README.md
 
 sbin_SCRIPTS = duo_unix_support.sh
-EXTRA_DIST = duo_unix_support.sh README.md
+EXTRA_DIST = duo_unix_support.sh README.md test_scrub_duo_conf.sh
+
+TESTS = test_scrub_duo_conf.sh

--- a/duo_unix_support/README.md
+++ b/duo_unix_support/README.md
@@ -13,7 +13,9 @@ Logs
 Configs
     /etc/duo/login_duo.conf
     /etc/duo/pam_duo.conf
-    (With the skeys scrubbed)
+    (Scrubbed: only allowlisted options are kept; skey is dropped, and
+    any userinfo in http_proxy is replaced with "REDACTED@". See the
+    allowlist in duo_unix_support.sh.)
     /etc/ssh/sshd_config
 
 PAM Stacks

--- a/duo_unix_support/duo_unix_support.sh
+++ b/duo_unix_support/duo_unix_support.sh
@@ -34,7 +34,7 @@ while true; do
     shift
 done
 
-echo -e "The Duo Unix support script gathers and aggregates information about your Duo Unix installation and the server it is installed on for easy sending to Duo Security support. This script is intended to be used with Debian, Ubuntu, RHEL, and CentOS systems. While use of this script is not required for support cases with Duo, it is highly recommended as it will expedite the support and debugging process. Namely, this script collects:\n\n\t* Logfiles such as auth.log, secure, and authlog from /var/log and /var/adm\n\t* PAM configurations in /etc/pam.d, such as common-auth or sshd\n\t* SSHD configurations in /etc/ssh\n\t* Information about the server distribution and relevant libraries such as SELinux or OpenSSL\n\t* Configurations for pam_duo and login_duo scrubbed of sensitive skeys\n\nThese files are typically asked for during support cases with Duo. We advise that you review any of these files prior to running this script should you wish to expunge any other information you deem sensitive from these files. For a full list of the information collected by this script, see ${README_INSTALL}/share/doc/duo_unix/duo_unix_support/README.md."
+echo -e "The Duo Unix support script gathers and aggregates information about your Duo Unix installation and the server it is installed on for easy sending to Duo Security support. This script is intended to be used with Debian, Ubuntu, RHEL, and CentOS systems. While use of this script is not required for support cases with Duo, it is highly recommended as it will expedite the support and debugging process. Namely, this script collects:\n\n\t* Logfiles such as auth.log, secure, and authlog from /var/log and /var/adm\n\t* PAM configurations in /etc/pam.d, such as common-auth or sshd\n\t* SSHD configurations in /etc/ssh\n\t* Information about the server distribution and relevant libraries such as SELinux or OpenSSL\n\t* Configurations for pam_duo and login_duo, scrubbed to include only an allowlist of non-sensitive options (skey and http_proxy userinfo are redacted)\n\nThese files are typically asked for during support cases with Duo. We advise that you review any of these files prior to running this script should you wish to expunge any other information you deem sensitive from these files. For a full list of the information collected by this script, see ${README_INSTALL}/share/doc/duo_unix/duo_unix_support/README.md."
 
 read -rp "Do you wish to run this program? [N/y] " user_input
 
@@ -134,16 +134,139 @@ if type make &>/dev/null; then
    echo "make=$MAKE_VER" | $GREP "make" >> configuration.txt
 fi
 
-# Copy over common configurations and scrub the skey from the configs
+# Emit an allowlisted subset of /etc/duo/*.conf into the bundle.
+scrub_duo_conf () {
+    src="$1"
+    dst="$2"
+    ( umask 077 && : > "$dst" ) || return 1
+    if ! awk '
+        BEGIN {
+            split("ikey host cafile http_proxy groups group failmode pushinfo noverify prompts autopush accept_env_factor fallback_local_ip https_timeout send_gecos gecos_parsed gecos_delim gecos_username_pos verified_push motd", a, " ")
+            for (i in a) allow[a[i]] = 1
+            dropped = 0
+        }
+        # Strip an inline "; ..." comment matching lib/ini.c semantics.
+        function strip_inline_comment(v,    i, c, prev) {
+            prev = ""
+            for (i = 1; i <= length(v); i++) {
+                c = substr(v, i, 1)
+                if (c == ";" && (prev == " " || prev == "\t" || prev == "")) {
+                    v = substr(v, 1, i - 1)
+                    break
+                }
+                prev = c
+            }
+            sub(/[[:space:]]+$/, "", v)
+            return v
+        }
+        # Replace userinfo in http_proxy with "REDACTED@", keeping the host.
+        function redact_userinfo(v,    lower, scheme_len, scheme, rest, i, c, auth_end, last_at) {
+            scheme_len = 0
+            lower = tolower(v)
+            if (substr(lower, 1, 7) == "http://") {
+                scheme_len = 7
+            } else if (substr(lower, 1, 8) == "https://") {
+                scheme_len = 8
+            }
+            scheme = substr(v, 1, scheme_len)
+            rest = substr(v, scheme_len + 1)
+            first_term = 0
+            for (i = 1; i <= length(rest); i++) {
+                c = substr(rest, i, 1)
+                if (c == "/" || c == "?" || c == "#") {
+                    first_term = i
+                    break
+                }
+            }
+            auth_end = (first_term > 0) ? first_term : length(rest) + 1
+            last_at = 0
+            for (i = 1; i < auth_end; i++) {
+                if (substr(rest, i, 1) == "@") {
+                    last_at = i
+                }
+            }
+            if (last_at == 0 && first_term > 0) {
+                # Fallback: "@" only appears past first_term.
+                for (i = first_term; i <= length(rest); i++) {
+                    if (substr(rest, i, 1) == "@") {
+                        last_at = i
+                        auth_end = length(rest) + 1
+                    }
+                }
+            }
+            if (last_at == 0) {
+                return v
+            }
+            if (auth_end > length(rest)) {
+                return scheme "REDACTED@" substr(rest, last_at + 1)
+            }
+            return scheme "REDACTED@" substr(rest, last_at + 1, auth_end - last_at - 1) substr(rest, auth_end)
+        }
+        {
+            line = $0
+            if (line ~ /^[[:space:]]*$/) {
+                print line
+                next
+            }
+            if (line ~ /^[[:space:]]*[#;]/) {
+                if (tolower(line) ~ /skey/) {
+                    dropped++
+                    next
+                }
+                print line
+                next
+            }
+            if (line ~ /^[[:space:]]*\[[^]]*\][[:space:]]*$/) {
+                print line
+                next
+            }
+            if (match(line, /^[[:space:]]*[A-Za-z_][A-Za-z0-9._-]*[[:space:]]*=/) == 0) {
+                next
+            }
+            eq = index(line, "=")
+            name = substr(line, 1, eq - 1)
+            sub(/^[[:space:]]+/, "", name)
+            sub(/[[:space:]]+$/, "", name)
+            if (!(name in allow)) {
+                dropped++
+                next
+            }
+            value = substr(line, eq + 1)
+            sub(/^[[:space:]]+/, "", value)
+            value = strip_inline_comment(value)
+            if (name == "http_proxy") {
+                value = redact_userinfo(value)
+            }
+            print name " = " value
+        }
+        END {
+            if (dropped > 0) {
+                print ""
+                print "; " dropped " option(s) from the original file were dropped by"
+                print "; duo_unix_support.sh because they are not on the support-bundle"
+                print "; allowlist. Names and values are withheld."
+            }
+        }
+    ' "$src" >> "$dst"; then
+        echo "Failed to scrub $src" >&2
+        return 1
+    fi
+}
 
 echo "* Successfully copied login_duo.conf"
-sed '/skey/d' /etc/duo/login_duo.conf > login_duo.conf
+if ! scrub_duo_conf /etc/duo/login_duo.conf login_duo.conf; then
+    echo "Aborting: could not produce scrubbed login_duo.conf" >&2
+    exit 1
+fi
 chmod --reference /etc/duo/login_duo.conf login_duo.conf
 
 # The user might not have pam_duo install on their system
 if [ -e '/etc/duo/pam_duo.conf' ]; then
     echo "* Successfully copied pam_duo.conf"
-    sed '/skey/d' /etc/duo/pam_duo.conf > pam_duo.conf
+    if ! scrub_duo_conf /etc/duo/pam_duo.conf pam_duo.conf; then
+        echo "Aborting: could not produce scrubbed pam_duo.conf" >&2
+        exit 1
+    fi
     chmod --reference /etc/duo/pam_duo.conf pam_duo.conf
 fi
 

--- a/duo_unix_support/test_scrub_duo_conf.sh
+++ b/duo_unix_support/test_scrub_duo_conf.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0-with-classpath-exception
+#
+# Regression tests for scrub_duo_conf in duo_unix_support.sh.
+# Sources the function directly from the shipping script.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COLLECTOR="${SCRIPT_DIR}/duo_unix_support.sh"
+
+if [ ! -f "${COLLECTOR}" ]; then
+    echo "cannot find duo_unix_support.sh next to test" >&2
+    exit 2
+fi
+
+FN_TMP="$(mktemp)"
+trap 'rm -f "${FN_TMP}"' EXIT
+
+awk '
+    /^scrub_duo_conf \(\) \{$/ { in_fn = 1 }
+    in_fn { print }
+    in_fn && /^\}$/ { exit }
+' "${COLLECTOR}" > "${FN_TMP}"
+
+if ! grep -q '^scrub_duo_conf ()' "${FN_TMP}"; then
+    echo "failed to extract scrub_duo_conf from ${COLLECTOR}" >&2
+    exit 2
+fi
+
+# shellcheck source=/dev/null
+. "${FN_TMP}"
+
+PASS=0
+FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -f "${FN_TMP}"; rm -rf "${TMP}"' EXIT
+
+# assert_scrub NAME INPUT FORBIDDEN_REGEX [REQUIRED_REGEX...]
+assert_scrub () {
+    local name="$1" ; shift
+    local input="$1" ; shift
+    local forbidden="$1" ; shift
+
+    local src="${TMP}/${name}.in"
+    local dst="${TMP}/${name}.out"
+    printf '%s' "${input}" > "${src}"
+
+    if ! scrub_duo_conf "${src}" "${dst}"; then
+        printf 'FAIL %s: scrub_duo_conf returned non-zero\n' "${name}" >&2
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    local perm
+    if perm=$(stat -c '%a' "${dst}" 2>/dev/null); then :
+    else perm=$(stat -f '%Lp' "${dst}"); fi
+    if [ "${perm}" != "600" ]; then
+        printf 'FAIL %s: expected mode 600, got %s\n' "${name}" "${perm}" >&2
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if [ -n "${forbidden}" ] && grep -qE "${forbidden}" "${dst}"; then
+        printf 'FAIL %s: forbidden regex %q matched in output:\n' "${name}" "${forbidden}" >&2
+        sed 's/^/    /' "${dst}" >&2
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    while [ "$#" -gt 0 ]; do
+        if ! grep -qE "$1" "${dst}"; then
+            printf 'FAIL %s: expected regex %q not found in output:\n' "${name}" "$1" >&2
+            sed 's/^/    /' "${dst}" >&2
+            FAIL=$((FAIL + 1))
+            return
+        fi
+        shift
+    done
+
+    PASS=$((PASS + 1))
+    printf 'ok   %s\n' "${name}"
+}
+
+assert_scrub baseline "$(cat <<'CONF'
+[duo]
+ikey = DIXXXXXXXXXXXXXXXXXX
+skey = REPLACE_ME_SKEY
+host = api-example.duosecurity.com
+http_proxy = http://user:pw@proxy.example.com:3128
+CONF
+)" 'REPLACE_ME_SKEY|user:pw|^skey' \
+   '^http_proxy = http://REDACTED@proxy\.example\.com:3128$' \
+   '^ikey = DIXXXXXXXXXXXXXXXXXX$'
+
+assert_scrub slash_in_pw "$(cat <<'CONF'
+[duo]
+http_proxy = http://user:my/password@proxy.example.com:3128
+CONF
+)" 'my/password' \
+   '^http_proxy = http://REDACTED@proxy\.example\.com:3128$'
+
+assert_scrub at_in_pw "$(cat <<'CONF'
+[duo]
+http_proxy = http://user:p@ss@proxy.example.com:3128
+CONF
+)" 'p@ss@|:p@ss' \
+   '^http_proxy = http://REDACTED@proxy\.example\.com:3128$'
+
+assert_scrub ipv6_host "$(cat <<'CONF'
+[duo]
+http_proxy = http://user:pw@[::1]:3128
+CONF
+)" 'user:pw@' \
+   '^http_proxy = http://REDACTED@\[::1\]:3128$'
+
+assert_scrub schemeless "$(cat <<'CONF'
+[duo]
+http_proxy = user:pw@proxy.corp:3128
+CONF
+)" 'user:pw' \
+   '^http_proxy = REDACTED@proxy\.corp:3128$'
+
+assert_scrub mixed_case_scheme "$(cat <<'CONF'
+[duo]
+http_proxy = HTTP://User:Pass@Proxy.Example.COM:3128
+CONF
+)" 'User:Pass' \
+   '^http_proxy = HTTP://REDACTED@Proxy\.Example\.COM:3128$'
+
+assert_scrub inline_semicolon_comment "$(cat <<'CONF'
+[duo]
+ikey = DIXXXX ; skey backup: 4MjRQ2NmRiM2Q1Y
+host = api-example.com  ; internal notes: PW
+CONF
+)" '4MjRQ2NmRiM2Q1Y|PW|skey backup|internal notes' \
+   '^ikey = DIXXXX$' \
+   '^host = api-example\.com$'
+
+assert_scrub section_header_junk "$(cat <<'CONF'
+[duo] skey = INSIDE_SECTION_HEADER
+[duo]
+ikey = ABC
+CONF
+)" 'INSIDE_SECTION_HEADER' \
+   '^ikey = ABC$'
+
+assert_scrub hyphenated_names "$(cat <<'CONF'
+[duo]
+verified-push = yes
+duo.host = api.example.com
+ikey = DIABC
+CONF
+)" 'verified-push|duo\.host' \
+   '^ikey = DIABC$' \
+   '2 option\(s\).*were dropped'
+
+assert_scrub no_dev_fips_mode "$(cat <<'CONF'
+[duo]
+ikey = DIABC
+dev_fips_mode = 1
+CONF
+)" '^dev_fips_mode' \
+   '^ikey = DIABC$' \
+   '1 option\(s\).*were dropped'
+
+assert_scrub skey_dropped "$(cat <<'CONF'
+[duo]
+skey = LEAKED
+ikey = KEPT
+CONF
+)" '^skey|LEAKED' \
+   '^ikey = KEPT$'
+
+assert_scrub skey_multiline_continuation_dropped "$(cat <<'CONF'
+[duo]
+ikey = DIABC
+skey =
+    REPLACE_ME_SKEY_ON_CONTINUATION
+host = api-example.com
+CONF
+)" 'REPLACE_ME_SKEY_ON_CONTINUATION|^skey' \
+   '^ikey = DIABC$' \
+   '^host = api-example\.com$'
+
+assert_scrub quoted_url_credentials_gone "$(cat <<'CONF'
+[duo]
+http_proxy = "http://alice:PW@proxy.example.com:3128"
+CONF
+)" 'alice:PW|alice|PW'
+
+assert_scrub path_query_preserves_host "$(cat <<'CONF'
+[duo]
+http_proxy = http://user:pw@proxy.example.com:3128/?token=abc@xyz
+CONF
+)" 'user:pw' \
+   '^http_proxy = http://REDACTED@proxy\.example\.com:3128/\?token=abc@xyz$'
+
+assert_scrub hash_in_group_pattern_preserved "$(cat <<'CONF'
+[duo]
+groups = admins #devops
+CONF
+)" '' \
+   '^groups = admins #devops$'
+
+assert_scrub skey_in_comment_dropped "$(cat <<'CONF'
+# backup skey: 4MjRQ2NmRiM2Q1Y
+[duo]
+ikey = DIABC
+; old_skey_note: this rotated 2024-01-01
+host = api.example.com
+CONF
+)" '4MjRQ2NmRiM2Q1Y|old_skey_note' \
+   '^ikey = DIABC$' \
+   '^host = api\.example\.com$'
+
+assert_scrub crlf_endings "$(printf '[duo]\r\nikey = DIABC\r\nskey = LEAKED\r\n')" \
+   'LEAKED' \
+   '^ikey = DIABC'
+
+assert_scrub trailing_whitespace "$(printf '[duo]\nikey = DIABC   \n')" \
+   'DIABC   $' \
+   '^ikey = DIABC$'
+
+echo
+echo "passed: ${PASS}, failed: ${FAIL}"
+[ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
Switch the pam_duo.conf / login_duo.conf redaction in `duo_unix_support/duo_unix_support.sh` from a substring denylist to an allowlist scrubber, and add a regression test suite wired into `make check`.