### PR TITLE
Sanitize server-supplied status and prompt strings

### DIFF
--- a/lib/duo.c
+++ b/lib/duo.c
@@ -67,15 +67,27 @@
 static char *
 __prompt_fn(void *arg, const char *prompt, char *buf, size_t bufsz)
 {
-    printf("%s", prompt);
+    char *safe = strdup(prompt);
+    if (safe == NULL) {
+        return (NULL);
+    }
+    duo_sanitize_str(safe);
+    printf("%s", safe);
     fflush(stdout);
+    free(safe);
     return (fgets(buf, bufsz, stdin));
 }
 
 static void
 __status_fn(void *arg, const char *msg)
 {
-    printf("%s\n", msg);
+    char *safe = strdup(msg);
+    if (safe == NULL) {
+        return;
+    }
+    duo_sanitize_str(safe);
+    printf("%s\n", safe);
+    free(safe);
 }
 
 struct duo_ctx *

--- a/lib/util.c
+++ b/lib/util.c
@@ -48,6 +48,23 @@ duo_set_boolean_option(const char *val)
     }
 }
 
+void
+duo_sanitize_str(char *s)
+{
+    if (s == NULL) {
+        return;
+    }
+    for (; *s != '\0'; s++) {
+        unsigned char c = (unsigned char)*s;
+        if (c == '\t' || c == '\n') {
+            continue;
+        }
+        if (c < 0x20 || c == 0x7F) {
+            *s = '?';
+        }
+    }
+}
+
 int
 duo_common_ini_handler(struct duo_config *cfg, const char *section,
     const char *name, const char*val)

--- a/lib/util.h
+++ b/lib/util.h
@@ -85,4 +85,9 @@ char *duo_split_at(char *s, char delimiter, unsigned int position);
 /* Free and zero out memory */
 void duo_zero_free(void *ptr, size_t size);
 
+/* Replace C0 control bytes (0x00-0x1F except \t and \n) and 0x7F with '?'
+ * in place, to prevent server-supplied strings from injecting terminal
+ * escape sequences when written to a TTY, PAM prompt, or syslog. */
+void duo_sanitize_str(char *s);
+
 #endif

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -81,7 +81,13 @@ __ini_handler(void *u, const char *section, const char *name, const char *val)
 static void
 __autopush_status_fn(void *arg, const char*msg)
 {
-    printf("%s\n", msg);
+    char *safe = strdup(msg);
+    if (safe == NULL) {
+        return;
+    }
+    duo_sanitize_str(safe);
+    printf("%s\n", safe);
+    free(safe);
 }
 
 static int

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -88,18 +88,31 @@ __ini_handler(void *u, const char *section, const char *name, const char *val)
 static void
 __duo_status(void *arg, const char *msg)
 {
-    pam_info((pam_handle_t *)arg, "%s", msg);
+    char *safe = strdup(msg);
+    if (safe == NULL) {
+        return;
+    }
+    duo_sanitize_str(safe);
+    pam_info((pam_handle_t *)arg, "%s", safe);
+    free(safe);
 }
 
 static char *
 __duo_prompt(void *arg, const char *prompt, char *buf, size_t bufsz)
 {
     char *p = NULL;
+    char *safe = strdup(prompt);
 
-    if (pam_prompt((pam_handle_t *)arg, PAM_PROMPT_ECHO_ON, &p,
-        "%s", prompt) != PAM_SUCCESS || p == NULL) {
+    if (safe == NULL) {
         return (NULL);
     }
+    duo_sanitize_str(safe);
+    if (pam_prompt((pam_handle_t *)arg, PAM_PROMPT_ECHO_ON, &p,
+        "%s", safe) != PAM_SUCCESS || p == NULL) {
+        free(safe);
+        return (NULL);
+    }
+    free(safe);
     strlcpy(buf, p, bufsz);
     free(p);
     return (buf);


### PR DESCRIPTION
Add `duo_sanitize_str()` and apply it in the login_duo / pam_duo status and prompt callbacks so C0 control bytes and DEL in server-supplied strings are replaced with `?` before reaching the terminal or the PAM conversation.