### PR TITLE
Treat getgrgid failures as errors in ga_init group resolution

### DIFF
--- a/compat/groupaccess.c
+++ b/compat/groupaccess.c
@@ -82,9 +82,19 @@ ga_init(const char *user, gid_t base)
 		free(groups_byname);
 		return (-1);
 	}
-	for (i = 0, j = 0; i < ngroups; i++)
+	for (i = 0, j = 0; i < ngroups; i++) {
 		if ((gr = getgrgid(groups_bygid[i])) != NULL)
 			groups_byname[j++] = strdup(gr->gr_name);
+		else {
+			free(groups_bygid);
+			for (i = 0; i < j; i++)
+				free(groups_byname[i]);
+			free(groups_byname);
+			groups_byname = NULL;
+			ngroups = 0;
+			return (-1);
+		}
+	}
 	free(groups_bygid);
 	return (ngroups = j);
 }

--- a/lib/util.c
+++ b/lib/util.c
@@ -223,7 +223,7 @@ duo_check_groups(struct passwd *pw, char **groups, int groups_cnt)
     if (groups_cnt > 0) {
         int matched = 0;
 
-        if (ga_init(pw->pw_name, pw->pw_gid) < 0) {
+        if (ga_init(pw->pw_name, pw->pw_gid) <= 0) {
             duo_log(LOG_ERR, "Couldn't get groups",
                 pw->pw_name, NULL, strerror(errno));
             return (-1);

--- a/tests/config.py
+++ b/tests/config.py
@@ -291,6 +291,14 @@ MOCKDUO_ADMINS_NO_USERS = DuoUnixConfig(
     group="admin,!users",
 )
 
+MOCKDUO_GROUPS_STAR = DuoUnixConfig(
+    ikey="DIXYZV6YM8IFYVWBINCA",
+    skey="yWHSMhWucAcp7qvuH3HWTaSaKABs8Gaddiv1NIRo",
+    host="localhost:4443",
+    cafile="certs/mockduo-ca.pem",
+    groups="*",
+)
+
 MOTD_CONF = DuoUnixConfig(
     ikey="DIXYZV6YM8IFYVWBINCA",
     skey="yWHSMhWucAcp7qvuH3HWTaSaKABs8Gaddiv1NIRo",

--- a/tests/groups_preload.c
+++ b/tests/groups_preload.c
@@ -22,7 +22,7 @@
 
 FILE *(*_fopen)(const char* filename, const char* mode);
 
-static struct passwd _passwd[6] = {
+static struct passwd _passwd[8] = {
         { "user1", "*", 1000, 1000, .pw_gecos = "gecos", .pw_dir = "/",
           .pw_shell = "/bin/sh" },
         { "user2", "*", 1001, 100, .pw_gecos = "gecos", .pw_dir = "/",
@@ -35,21 +35,30 @@ static struct passwd _passwd[6] = {
           .pw_shell = "/bin/sh" },
         { "noshell", "*", 1005, 1005, .pw_gecos = "gecos", .pw_dir = "/",
           .pw_shell = NULL },
+        { "orphan", "*", 1006, 59999, .pw_gecos = "gecos", .pw_dir = "/",
+          .pw_shell = "/bin/sh" },
+        { "partial", "*", 1007, 59999, .pw_gecos = "gecos", .pw_dir = "/",
+          .pw_shell = "/bin/sh" },
 };
 
 /* Supplemental groups */
-static char *_gr_users[] = { "user1", "admin1", NULL };
+static char *_gr_users[] = { "user1", "admin1", "partial", NULL };
 static char *_gr_admin[] = { "admin2", NULL };
 static char *_gr_spaces[] = { "user2", NULL };
 static char *_gr_no_spaces[] = { "weirdo", NULL };
 static char *_gr_more_spaces[] = { "admin1", NULL };
+static char *_gr_empty[] = { NULL };
 
-static struct group _groups[5] = {
+static struct group _groups[9] = {
         { "users", NULL, 100, _gr_users },
         { "admin", NULL, 10, _gr_admin },
         { "users with spaces", NULL, 200, _gr_spaces },
         { "no_spaces\\here", NULL, 201, _gr_no_spaces },
         { "more spaces", NULL, 202, _gr_more_spaces },
+        { "user1grp", NULL, 1000, _gr_empty },
+        { "admin2grp", NULL, 1003, _gr_empty },
+        { "weirdogrp", NULL, 1004, _gr_empty },
+        { "noshellgrp", NULL, 1005, _gr_empty },
 };
 
 static int _group_ptr = 0;
@@ -85,6 +94,15 @@ struct group *
 getgrgid(gid_t gid)
 {
         int i;
+        char *fail_gid_str = getenv("GETGRGID_FAIL");
+
+        if (fail_gid_str != NULL) {
+                gid_t fail_gid = (gid_t)atoi(fail_gid_str);
+                if (gid == fail_gid) {
+                        errno = EIO;
+                        return (NULL);
+                }
+        }
 
         for (i = 0; i < sizeof(_groups) / sizeof(_groups)[0]; i++) {
                 if (_groups[i].gr_gid == gid)

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -30,6 +30,7 @@ from config import (
     MOCKDUO_GECOS_LONG_DELIM,
     MOCKDUO_GECOS_SEND_UNPARSED,
     MOCKDUO_GECOS_SLASH_DELIM_3_POS,
+    MOCKDUO_GROUPS_STAR,
     MOCKDUO_USERS,
     MOCKDUO_USERS_ADMINS,
     MOTD_CONF,
@@ -516,6 +517,70 @@ class TestLoginDuoGroups(CommonTestCase):
                 result["stderr"],
                 r"User preauth-allow bypassed Duo 2FA due to user's UNIX group",
             )
+
+
+class TestLoginDuoGroupLookupFailures(CommonTestCase):
+    def run(self, result=None):
+        with MockDuo(NORMAL_CERT):
+            return super(TestLoginDuoGroupLookupFailures, self).run(result)
+
+    def test_all_gids_unresolvable_denied(self):
+        """User with no resolvable GIDs must be denied, not bypassed."""
+        with TempConfig(MOCKDUO_GROUPS_STAR) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "orphan", "true"],
+                env={"UID": "1006"},
+                preload_script=os.path.join(TESTDIR, "groups.py"),
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Couldn't get groups",
+            )
+            self.assertNotEqual(result["returncode"], 0)
+
+    def test_partial_group_resolution_failure_denied(self):
+        """User whose primary GID fails getgrgid must be denied even if
+        supplementary groups resolve."""
+        with TempConfig(MOCKDUO_USERS) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "partial", "true"],
+                env={"UID": "1007"},
+                preload_script=os.path.join(TESTDIR, "groups.py"),
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Couldn't get groups",
+            )
+            self.assertNotEqual(result["returncode"], 0)
+
+    def test_nss_outage_for_matching_group_denied(self):
+        """Simulated NSS outage for a GID that would normally match must
+        deny, not bypass."""
+        with TempConfig(MOCKDUO_USERS) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "user1", "true"],
+                env={"UID": "1000", "GETGRGID_FAIL": "100"},
+                preload_script=os.path.join(TESTDIR, "groups.py"),
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Couldn't get groups",
+            )
+            self.assertNotEqual(result["returncode"], 0)
+
+    def test_nss_outage_for_primary_gid_denied(self):
+        """Simulated NSS outage for user's primary GID must deny."""
+        with TempConfig(MOCKDUO_GROUPS_STAR) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "user1", "true"],
+                env={"UID": "1000", "GETGRGID_FAIL": "1000"},
+                preload_script=os.path.join(TESTDIR, "groups.py"),
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Couldn't get groups",
+            )
+            self.assertNotEqual(result["returncode"], 0)
 
 
 class TestLoginDuoInteractive(CommonSuites.Interactive):


### PR DESCRIPTION
## Summary of the change
ga_init() now returns -1 if any GID obtained from getgrouplist() cannot be resolved to a group name via getgrgid(), rather than silently dropping unresolvable GIDs from the list. duo_check_groups() additionally treats a zero return from ga_init() as an error.

## Test Plan
Existing and new tests pass
