### PR TITLE
Strip control characters from server-supplied strings before output

### DIFF
--- a/lib/duo.c
+++ b/lib/duo.c
@@ -67,7 +67,12 @@
 static char *
 __prompt_fn(void *arg, const char *prompt, char *buf, size_t bufsz)
 {
-    printf("%s", prompt);
+    char *sanitized = strdup(prompt);
+    if (sanitized != NULL) {
+        duo_sanitize_str(sanitized);
+        printf("%s", sanitized);
+        free(sanitized);
+    }
     fflush(stdout);
     return (fgets(buf, bufsz, stdin));
 }
@@ -75,7 +80,12 @@ __prompt_fn(void *arg, const char *prompt, char *buf, size_t bufsz)
 static void
 __status_fn(void *arg, const char *msg)
 {
-    printf("%s\n", msg);
+    char *sanitized = strdup(msg);
+    if (sanitized != NULL) {
+        duo_sanitize_str(sanitized);
+        printf("%s\n", sanitized);
+        free(sanitized);
+    }
 }
 
 struct duo_ctx *

--- a/lib/util.c
+++ b/lib/util.c
@@ -265,6 +265,18 @@ _add_to_log(char *buf, size_t buf_sz, int pos, const char *format,
 }
 
 void
+duo_sanitize_str(char *s)
+{
+    for (; *s != '\0'; s++) {
+        unsigned char c = (unsigned char)*s;
+        if (c == '\t' || c == '\n')
+            continue;
+        if (c < 0x20 || c == 0x7F)
+            *s = '?';
+    }
+}
+
+void
 duo_log(int priority, const char *msg, const char *user, const char *ip,
         const char *err)
 {
@@ -273,6 +285,7 @@ duo_log(int priority, const char *msg, const char *user, const char *ip,
     pos = _add_to_log(buf, sizeof(buf), pos, " for '%s'", user);
     pos = _add_to_log(buf, sizeof(buf), pos, " from %s", ip);
     pos = _add_to_log(buf, sizeof(buf), pos, ": %s", err);
+    duo_sanitize_str(buf);
     duo_syslog(priority, "%s", buf);
 }
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -82,6 +82,9 @@ const char *duo_local_ip();
 
 char *duo_split_at(char *s, char delimiter, unsigned int position);
 
+/* Replace non-printable characters (except \n and \t) with '?'. */
+void duo_sanitize_str(char *s);
+
 /* Free and zero out memory */
 void duo_zero_free(void *ptr, size_t size);
 

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -81,7 +81,12 @@ __ini_handler(void *u, const char *section, const char *name, const char *val)
 static void
 __autopush_status_fn(void *arg, const char*msg)
 {
-    printf("%s\n", msg);
+    char *sanitized = strdup(msg);
+    if (sanitized != NULL) {
+        duo_sanitize_str(sanitized);
+        printf("%s\n", sanitized);
+        free(sanitized);
+    }
 }
 
 static int

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -88,18 +88,30 @@ __ini_handler(void *u, const char *section, const char *name, const char *val)
 static void
 __duo_status(void *arg, const char *msg)
 {
-    pam_info((pam_handle_t *)arg, "%s", msg);
+    char *sanitized = strdup(msg);
+    if (sanitized != NULL) {
+        duo_sanitize_str(sanitized);
+        pam_info((pam_handle_t *)arg, "%s", sanitized);
+        free(sanitized);
+    }
 }
 
 static char *
 __duo_prompt(void *arg, const char *prompt, char *buf, size_t bufsz)
 {
     char *p = NULL;
+    char *sanitized = strdup(prompt);
 
+    if (sanitized == NULL)
+        return (NULL);
+
+    duo_sanitize_str(sanitized);
     if (pam_prompt((pam_handle_t *)arg, PAM_PROMPT_ECHO_ON, &p,
-        "%s", prompt) != PAM_SUCCESS || p == NULL) {
+        "%s", sanitized) != PAM_SUCCESS || p == NULL) {
+        free(sanitized);
         return (NULL);
     }
+    free(sanitized);
     strlcpy(buf, p, bufsz);
     free(p);
     return (buf);

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -369,6 +369,39 @@ class CommonSuites:
             # 1.x seconds + 2.x seconds executed twice
             self.assertGreater(execution_time, 6)
 
+    class EscapeInjection(CommonTestCase):
+        def run(self, result=None):
+            with MockDuo(NORMAL_CERT):
+                return super(CommonSuites.EscapeInjection, self).run(result)
+
+        def test_fail_message_sanitized(self):
+            """stat=FAIL message with escape sequences is sanitized in log output"""
+            with TempConfig(MOCKDUO_CONF) as temp:
+                result = self.call_binary(
+                    ["-d", "-c", temp.name, "-f", "escape-inject-fail", "true"]
+                )
+                for line in result["stderr"]:
+                    self.assertNotIn("\x1b", line,
+                        "ESC byte found in stderr output")
+                    self.assertNotIn("\x07", line,
+                        "BEL byte found in stderr output")
+                self.assertRegexSomeline(
+                    result["stderr"],
+                    r"Failed Duo login for 'escape-inject-fail'.*40001.*\?",
+                )
+
+        def test_deny_status_msg_sanitized(self):
+            """preauth deny status_msg with escape sequences is sanitized"""
+            with TempConfig(MOCKDUO_CONF) as temp:
+                result = self.call_binary(
+                    ["-d", "-c", temp.name, "-f", "escape-inject-deny", "true"]
+                )
+                for line in result["stdout"] + result["stderr"]:
+                    self.assertNotIn("\x1b", line,
+                        "ESC byte found in output")
+                    self.assertNotIn("\x07", line,
+                        "BEL byte found in output")
+
     class Hosts(CommonTestCase):
         def run(self, result=None):
             with MockDuo(NORMAL_CERT):

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -256,6 +256,17 @@ class MockDuoHandler(BaseHTTPRequestHandler):
                     "code": 1000,
                     "message": "Pre-authentication failed",
                 }
+            elif self.args["username"] == "escape-inject-fail":
+                ret = {
+                    "stat": "FAIL",
+                    "code": 40001,
+                    "message": "\x1b]0;PWNED\x07\x1b[1;31minjected\x1b[0m",
+                }
+            elif self.args["username"] == "escape-inject-deny":
+                ret["response"] = {
+                    "result": "deny",
+                    "status_msg": "\x1b]52;c;dGVzdA==\x07malicious",
+                }
             elif self.args["username"] == "preauth-deny":
                 ret["response"] = {"result": "deny", "status_msg": "preauth-denied"}
             elif self.args["username"] == "preauth-allow":

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -197,6 +197,11 @@ class TestLoginDuoPreauthStates(CommonSuites.PreauthStates):
         return login_duo(*args)
 
 
+class TestLoginDuoEscapeInjection(CommonSuites.EscapeInjection):
+    def call_binary(self, *args):
+        return login_duo(*args)
+
+
 class TestLoginDuoHosts(CommonSuites.Hosts):
     def call_binary(self, *args):
         return login_duo(*args)

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -178,6 +178,11 @@ class TestPamPreauthStates(CommonSuites.PreauthStates):
         return pam_duo(*args)
 
 
+class TestPamEscapeInjection(CommonSuites.EscapeInjection):
+    def call_binary(self, *args):
+        return pam_duo(*args)
+
+
 @unittest.skipIf(sys.platform == "sunos5", SOLARIS_ISSUE)
 class TestPamHosts(CommonSuites.Hosts):
     def call_binary(self, *args, **kwargs):

--- a/tests/unity_tests/Makefile.am
+++ b/tests/unity_tests/Makefile.am
@@ -12,7 +12,7 @@ TESTS_ENVIRONMENT = env BUILDDIR=$(abs_top_builddir)/unityrunner
 
 SUBDIRS = $(UNITY_VERSION)
 
-UNITY_TESTS = unityrunner add_param_test common_ini_wrong_flag_test common_ini_failmode_test common_ini_prompts_test common_ini_https_timeout common_ini_string_options common_ini_bool_options_test add_groupname_test gecos_ini_test duo_log_test https_ipaddr_test
+UNITY_TESTS = unityrunner add_param_test common_ini_wrong_flag_test common_ini_failmode_test common_ini_prompts_test common_ini_https_timeout common_ini_string_options common_ini_bool_options_test add_groupname_test gecos_ini_test duo_log_test https_ipaddr_test sanitize_str_test
 
 # Create the unity runner executable
 check_PROGRAMS = $(UNITY_TESTS)

--- a/tests/unity_tests/sanitize_str_test.c
+++ b/tests/unity_tests/sanitize_str_test.c
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-with-classpath-exception
+ *
+ * sanitize_str_test.c
+ *
+ * Copyright (c) 2026 Cisco Systems, Inc. and/or its affiliates
+ * All rights reserved.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "src/unity.h"
+#include "util.h"
+
+extern void setUp(void) {};
+extern void tearDown(void) {};
+
+static void test_printable_unchanged(void) {
+    char s[] = "Hello, World! 123 ~`@#$%^&*()";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING("Hello, World! 123 ~`@#$%^&*()", s);
+}
+
+static void test_empty_string(void) {
+    char s[] = "";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING("", s);
+}
+
+static void test_tab_preserved(void) {
+    char s[] = "col1\tcol2\tcol3";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING("col1\tcol2\tcol3", s);
+}
+
+static void test_newline_preserved(void) {
+    char s[] = "line1\nline2\n";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING("line1\nline2\n", s);
+}
+
+static void test_escape_replaced(void) {
+    /* ESC = 0x1b */
+    char s[] = "before\x1b[31mred\x1b[0mafter";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING("before?[31mred?[0mafter", s);
+}
+
+static void test_bel_replaced(void) {
+    /* BEL = 0x07 */
+    char s[] = "\x1b]52;c;dGVzdA==\x07";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING("?]52;c;dGVzdA==?", s);
+}
+
+static void test_osc_title_replaced(void) {
+    /* OSC 0 set title: ESC ] 0 ; PWNED BEL */
+    char s[] = "\x1b]0;PWNED\x07rest";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING("?]0;PWNED?rest", s);
+}
+
+static void test_null_byte_terminates(void) {
+    /* Ensure we stop at NUL and don't overrun */
+    char s[] = "abc\x1b\x00xyz";
+    duo_sanitize_str(s);
+    /* Only first 4 chars matter (abc + replaced ESC), NUL terminates */
+    TEST_ASSERT_EQUAL_STRING("abc?", s);
+}
+
+static void test_del_replaced(void) {
+    char s[] = "test\x7fmore";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING("test?more", s);
+}
+
+static void test_high_bytes_preserved(void) {
+    /* Bytes >= 0x80 pass through (valid UTF-8 multi-byte sequences) */
+    char s[] = "a\x80\xff" "b";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING("a\x80\xff" "b", s);
+}
+
+static void test_utf8_preserved(void) {
+    /* Valid multi-byte UTF-8: é (U+00E9), ñ (U+00F1), 日 (U+65E5) */
+    char s[] = "caf\xc3\xa9 espa\xc3\xb1ol \xe6\x97\xa5\xe6\x9c\xac";
+    char expected[] = "caf\xc3\xa9 espa\xc3\xb1ol \xe6\x97\xa5\xe6\x9c\xac";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING(expected, s);
+}
+
+static void test_utf8_4byte_preserved(void) {
+    /* 4-byte UTF-8: U+1F600 (emoji grinning face) */
+    char s[] = "hi \xf0\x9f\x98\x80 there";
+    char expected[] = "hi \xf0\x9f\x98\x80 there";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING(expected, s);
+}
+
+static void test_mixed_controls(void) {
+    /* Mix of printable, tab, newline, and various control chars */
+    char s[] = "ok\t\x01\x02\nfine\x1b\x07";
+    duo_sanitize_str(s);
+    TEST_ASSERT_EQUAL_STRING("ok\t??\nfine??", s);
+}
+
+static void test_all_low_controls_except_tab_newline(void) {
+    /* 0x01 through 0x1f, excluding 0x09 (tab) and 0x0a (newline) */
+    char input[32];
+    char expected[32];
+    int i, j = 0, k = 0;
+
+    for (i = 1; i <= 0x1f; i++) {
+        input[j++] = (char)i;
+        if (i == '\t' || i == '\n') {
+            expected[k++] = (char)i;
+        } else {
+            expected[k++] = '?';
+        }
+    }
+    input[j] = '\0';
+    expected[k] = '\0';
+
+    duo_sanitize_str(input);
+    TEST_ASSERT_EQUAL_STRING(expected, input);
+}
+
+static void test_realistic_fail_message(void) {
+    /* Simulates what a stat=FAIL message with escape injection looks like */
+    char s[] = "40001: \x1b]0;PWNED\x07\x1b]52;c;ZWNobyBwd25lZA==\x07\x1b[1;31m! Access denied\x1b[0m";
+    duo_sanitize_str(s);
+    /* All ESC and BEL replaced with '?' */
+    TEST_ASSERT_EQUAL_STRING("40001: ?]0;PWNED??]52;c;ZWNobyBwd25lZA==??[1;31m! Access denied?[0m", s);
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_printable_unchanged);
+    RUN_TEST(test_empty_string);
+    RUN_TEST(test_tab_preserved);
+    RUN_TEST(test_newline_preserved);
+    RUN_TEST(test_escape_replaced);
+    RUN_TEST(test_bel_replaced);
+    RUN_TEST(test_osc_title_replaced);
+    RUN_TEST(test_null_byte_terminates);
+    RUN_TEST(test_del_replaced);
+    RUN_TEST(test_high_bytes_preserved);
+    RUN_TEST(test_utf8_preserved);
+    RUN_TEST(test_utf8_4byte_preserved);
+    RUN_TEST(test_mixed_controls);
+    RUN_TEST(test_all_low_controls_except_tab_newline);
+    RUN_TEST(test_realistic_fail_message);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary of the change
Add duo_sanitize_str() which replaces C0 control characters (0x00-0x1F except tab and newline) and DEL (0x7F) with '?' in a string. Apply it in duo_log() before writing to stderr/syslog, and in the status/prompt callbacks in login_duo and pam_duo before writing to the terminal or PAM conversation.

## Test Plan
New and existing tests should pass
