### PR TITLE
Fix memory safety issues in ga_init error paths

### DIFF
--- a/compat/groupaccess.c
+++ b/compat/groupaccess.c
@@ -75,17 +75,20 @@ ga_init(const char *user, gid_t base)
 	    !((groups_byname = calloc(ngroups, sizeof(*groups_byname))))) {
 		free(groups_bygid);
 		free(groups_byname);
+		groups_byname = NULL;
+		ngroups = 0;
 		return (-1);
 	}
 	if (getgrouplist(user, base, groups_bygid, &ngroups) == -1) {
 		free(groups_bygid);
 		free(groups_byname);
+		groups_byname = NULL;
+		ngroups = 0;
 		return (-1);
 	}
 	for (i = 0, j = 0; i < ngroups; i++) {
-		if ((gr = getgrgid(groups_bygid[i])) != NULL)
-			groups_byname[j++] = strdup(gr->gr_name);
-		else {
+		if ((gr = getgrgid(groups_bygid[i])) == NULL ||
+		    (groups_byname[j] = strdup(gr->gr_name)) == NULL) {
 			free(groups_bygid);
 			for (i = 0; i < j; i++)
 				free(groups_byname[i]);
@@ -94,6 +97,7 @@ ga_init(const char *user, gid_t base)
 			ngroups = 0;
 			return (-1);
 		}
+		j++;
 	}
 	free(groups_bygid);
 	return (ngroups = j);
@@ -152,5 +156,6 @@ ga_free(void)
 			free(groups_byname[i]);
 		ngroups = 0;
 		free(groups_byname);
+		groups_byname = NULL;
 	}
 }

--- a/tests/unity_tests/Makefile.am
+++ b/tests/unity_tests/Makefile.am
@@ -12,7 +12,7 @@ TESTS_ENVIRONMENT = env BUILDDIR=$(abs_top_builddir)/unityrunner
 
 SUBDIRS = $(UNITY_VERSION)
 
-UNITY_TESTS = unityrunner add_param_test common_ini_wrong_flag_test common_ini_failmode_test common_ini_prompts_test common_ini_https_timeout common_ini_string_options common_ini_bool_options_test add_groupname_test gecos_ini_test duo_log_test https_ipaddr_test sanitize_str_test
+UNITY_TESTS = unityrunner add_param_test common_ini_wrong_flag_test common_ini_failmode_test common_ini_prompts_test common_ini_https_timeout common_ini_string_options common_ini_bool_options_test add_groupname_test gecos_ini_test duo_log_test https_ipaddr_test sanitize_str_test ga_init_retry_test
 
 # Create the unity runner executable
 check_PROGRAMS = $(UNITY_TESTS)

--- a/tests/unity_tests/ga_init_retry_test.c
+++ b/tests/unity_tests/ga_init_retry_test.c
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-with-classpath-exception
+ *
+ * ga_init_retry_test.c
+ *
+ * Copyright (c) 2026 Cisco Systems, Inc. and/or its affiliates
+ * All rights reserved.
+ */
+
+#include <sys/types.h>
+#include <grp.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/unity.h"
+#include "groupaccess.h"
+
+extern void setUp(void) {};
+extern void tearDown(void) {};
+
+static int getgrouplist_call_count;
+static int getgrouplist_fail_on_call;
+
+/*
+ * Mock getgrouplist: when getgrouplist_fail_on_call is set, fail on that
+ * call number and write back a large ngroups value (simulating user with
+ * more groups than buffer can hold).
+ */
+int
+#ifdef __APPLE__
+getgrouplist(const char *user, int group, int *groups, int *ngroups)
+#else
+getgrouplist(const char *user, gid_t group, gid_t *groups, int *ngroups)
+#endif
+{
+	getgrouplist_call_count++;
+	if (getgrouplist_fail_on_call == getgrouplist_call_count) {
+		*ngroups = *ngroups + 100;
+		return (-1);
+	}
+	groups[0] = group;
+	*ngroups = 1;
+	return 1;
+}
+
+static struct group test_group = { "testgroup", NULL, 1000, NULL };
+
+struct group *
+getgrgid(gid_t gid)
+{
+	test_group.gr_gid = gid;
+	return &test_group;
+}
+
+/*
+ * Verify that when ga_init() fails due to getgrouplist overflow,
+ * then a second ga_init() call must not crash (UAF/double-free).
+ */
+void test_ga_init_retry_after_getgrouplist_failure(void)
+{
+	int ret;
+
+	getgrouplist_call_count = 0;
+	getgrouplist_fail_on_call = 1;
+
+	ret = ga_init("testuser", 1000);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	/* Second call must not crash — this is the bug scenario. */
+	getgrouplist_fail_on_call = 0;
+	ret = ga_init("testuser", 1000);
+	TEST_ASSERT_EQUAL(1, ret);
+
+	ga_free();
+}
+
+/*
+ * Verify consecutive getgrouplist failures don't accumulate corruption.
+ */
+void test_ga_init_multiple_failures(void)
+{
+	int ret;
+
+	getgrouplist_call_count = 0;
+	getgrouplist_fail_on_call = 1;
+
+	ret = ga_init("testuser", 1000);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	getgrouplist_call_count = 0;
+	ret = ga_init("testuser", 1000);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	getgrouplist_call_count = 0;
+	ret = ga_init("testuser", 1000);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	/* Now succeed — must not crash. */
+	getgrouplist_fail_on_call = 0;
+	ret = ga_init("testuser", 1000);
+	TEST_ASSERT_EQUAL(1, ret);
+
+	ga_free();
+}
+
+int main(void)
+{
+	UNITY_BEGIN();
+	RUN_TEST(test_ga_init_retry_after_getgrouplist_failure);
+	RUN_TEST(test_ga_init_multiple_failures);
+	return UNITY_END();
+}


### PR DESCRIPTION
## Summary of the change
Reset static state (groups_byname, ngroups) on all error paths in ga_init() so that a subsequent call does not operate on stale pointers. Also NULL groups_byname in ga_free() after releasing it, and treat strdup() failure the same as getgrgid() failure in the group-name resolution loop.

Add a unit test that exercises the retry-after-failure path.

## Test Plan
New and existing tests should pass

