### PR TITLE
Add an option to disable CA certificate pinning

### DIFF
--- a/duo_unix_support/duo_unix_support.sh
+++ b/duo_unix_support/duo_unix_support.sh
@@ -141,7 +141,7 @@ scrub_duo_conf () {
     ( umask 077 && : > "$dst" ) || return 1
     if ! awk '
         BEGIN {
-            split("ikey host cafile http_proxy groups group failmode pushinfo noverify prompts autopush accept_env_factor fallback_local_ip https_timeout send_gecos gecos_parsed gecos_delim gecos_username_pos verified_push motd", a, " ")
+            split("ikey host cafile http_proxy groups group failmode pushinfo noverify prompts autopush accept_env_factor fallback_local_ip https_timeout send_gecos gecos_parsed gecos_delim gecos_username_pos verified_push motd disable_ca_pinning", a, " ")
             for (i in a) allow[a[i]] = 1
             dropped = 0
         }

--- a/lib/duo.h
+++ b/lib/duo.h
@@ -31,6 +31,7 @@ typedef enum {
 #define DUO_ENV_VAR_NAME "DUO_PASSCODE"
 
 #define DUO_NO_TIMEOUT -1
+#define DUO_USE_SYSTEM_CERTS "##SYSTEM##"
 
 typedef struct duo_ctx duo_t;
 

--- a/lib/https.c
+++ b/lib/https.c
@@ -723,6 +723,14 @@ https_init(const char *cafile, const char *http_proxy)
     } else if (cafile[0] == '\0') {
         /* Skip verification */
         SSL_CTX_set_verify(ctx.ssl_ctx, SSL_VERIFY_NONE, NULL);
+    } else if (strcmp(cafile, HTTPS_USE_SYSTEM_CERTS) == 0) {
+        /* Use OS trust store without pinning, TLS verification still enforced */
+        if (!SSL_CTX_set_default_verify_paths(ctx.ssl_ctx)) {
+            SSL_CTX_free(ctx.ssl_ctx);
+            ctx.errstr = _SSL_strerror();
+            return (HTTPS_ERR_CLIENT);
+        }
+        SSL_CTX_set_verify(ctx.ssl_ctx, SSL_VERIFY_PEER, NULL);
     } else {
         /* Load CA cert from file */
         if (!SSL_CTX_load_verify_locations(ctx.ssl_ctx,

--- a/lib/https.h
+++ b/lib/https.h
@@ -22,6 +22,8 @@ typedef enum {
     HTTPS_ERR_SERVER,   /* something the server did */
 } HTTPScode;
 
+#define HTTPS_USE_SYSTEM_CERTS "##SYSTEM##"
+
 /* Initialize HTTPS library */
 HTTPScode https_init(const char *cafile, const char *http_proxy);
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -165,6 +165,8 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
         }
     } else if (strcmp(name, "verified_push") == 0) {
         cfg->verified_push = duo_set_boolean_option(val);
+    } else if (strcmp(name, "disable_ca_pinning") == 0) {
+        cfg->disable_ca_pinning = duo_set_boolean_option(val);
     } else {
         /* Couldn't handle the option, maybe it's target specific? */
         return (0);

--- a/lib/util.h
+++ b/lib/util.h
@@ -46,6 +46,7 @@ struct duo_config {
     int  send_gecos;
     int  gecos_username_pos;
     int  verified_push;
+    int  disable_ca_pinning;
 };
 
 void duo_config_default(struct duo_config *cfg);

--- a/login_duo/login_duo.8
+++ b/login_duo/login_duo.8
@@ -103,6 +103,16 @@ If unable to determine the authentication users's IP address, fallback on the
 IP address of the server. Default is "no".
 .It Cm https_timeout
 Set to the number of seconds to wait for HTTPS responses from Duo Security. If Duo Security takes longer than the configured number of seconds to respond to the preauth API call, the configured failmode is triggered. Other network operations such as DNS resolution, TCP connection establishment, and the SSL handshake have their own independent timeout and retry logic. Default is 0, which disables the HTTPS timeout.
+.It Cm disable_ca_pinning
+Disable the built-in CA certificate pinning and use the operating system's
+trust store for TLS certificate validation instead. TLS verification is still
+enforced; only the set of trusted root certificates changes. This may be
+required in environments that use TLS inspection or private PKI. Can be
+.Dq Li yes
+or
+.Dq Li no .
+Default is
+.Dq Li no .
 .El
 .Pp
 An example configuration file:

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -133,7 +133,7 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     struct in_addr addr;
     duo_t *duo;
     duo_code_t code;
-    const char *config, *p, *duouser;
+    const char *config, *p, *duouser, *cafile;
     const char *ip, *host = NULL;
     char buf[64];
     int i, flags, ret, prompts, matched;
@@ -239,9 +239,16 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     }
 
     /* Try Duo auth. */
+    if (cfg.noverify) {
+        cafile = "";
+    } else if (cfg.disable_ca_pinning) {
+        cafile = DUO_USE_SYSTEM_CERTS;
+    } else {
+        cafile = cfg.cafile;
+    }
     if ((duo = duo_open(cfg.apihost, cfg.ikey, cfg.skey,
                     "login_duo/" PACKAGE_VERSION,
-                    cfg.noverify ? "" : cfg.cafile,
+                    cafile,
                     cfg.https_timeout, cfg.http_proxy)) == NULL) {
         duo_log(LOG_ERR, "Couldn't open Duo API handle",
             pw->pw_name, host, NULL);

--- a/pam_duo/pam_duo.8
+++ b/pam_duo/pam_duo.8
@@ -70,6 +70,16 @@ IP. Default is "no".
 .It Cm send_gecos
 Instead of using the unix username, send Duo the contents of the GECOS field
 from /etc/passwd.  Default is "no".
+.It Cm disable_ca_pinning
+Disable the built-in CA certificate pinning and use the operating system's
+trust store for TLS certificate validation instead. TLS verification is still
+enforced; only the set of trusted root certificates changes. This may be
+required in environments that use TLS inspection or private PKI. Can be
+.Dq Li yes
+or
+.Dq Li no .
+Default is
+.Dq Li no .
 .El
 .Pp
 An example configuration file:

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -135,7 +135,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
      * without.
      */
     duopam_const char *ip, *service, *user;
-    const char *cmd, *p, *host;
+    const char *cmd, *p, *host, *cafile;
     const char *config = DUO_CONF;
 
     int i, flags, pam_err, matched;
@@ -249,9 +249,16 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
     }
 
     /* Try Duo auth */
+    if (cfg.noverify) {
+        cafile = "";
+    } else if (cfg.disable_ca_pinning) {
+        cafile = DUO_USE_SYSTEM_CERTS;
+    } else {
+        cafile = cfg.cafile;
+    }
     if ((duo = duo_open(cfg.apihost, cfg.ikey, cfg.skey,
                     "pam_duo/" PACKAGE_VERSION,
-                    cfg.noverify ? "" : cfg.cafile, cfg.https_timeout, cfg.http_proxy)) == NULL) {
+                    cafile, cfg.https_timeout, cfg.http_proxy)) == NULL) {
         duo_log(LOG_ERR, "Couldn't open Duo API handle", pw->pw_name, host, NULL);
         close_config(&cfg);
         return (PAM_SERVICE_ERR);

--- a/tests/confs/mockduo_disable_ca_pinning.conf
+++ b/tests/confs/mockduo_disable_ca_pinning.conf
@@ -1,0 +1,5 @@
+[duo]
+ikey = DIXYZV6YM8IFYVWBINCA
+skey = yWHSMhWucAcp7qvuH3HWTaSaKABs8Gaddiv1NIRo
+host = localhost:4443
+disable_ca_pinning = true

--- a/tests/unity_tests/common_ini_bool_options_test.c
+++ b/tests/unity_tests/common_ini_bool_options_test.c
@@ -162,6 +162,27 @@ static void test_fallback_local_ip_false() {
     TEST_ASSERT_EQUAL(expected_cfg_value, cfg.local_ip_fallback);
 }
 
+/* Test duo_common_ini_handler disable_ca_pinning flag */
+static void test_disable_ca_pinning_true() {
+    struct duo_config cfg = {0};
+    char *name = "disable_ca_pinning";
+    char *value = "true";
+    int expected_cfg_value = 1;
+
+    duo_common_ini_handler(&cfg, SECTION, name, value);
+    TEST_ASSERT_EQUAL(expected_cfg_value, cfg.disable_ca_pinning);
+}
+
+static void test_disable_ca_pinning_false() {
+    struct duo_config cfg = {0};
+    char *name = "disable_ca_pinning";
+    char *value = "false";
+    int expected_cfg_value = 0;
+
+    duo_common_ini_handler(&cfg, SECTION, name, value);
+    TEST_ASSERT_EQUAL(expected_cfg_value, cfg.disable_ca_pinning);
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(test_set_boolean_option_yes);
@@ -183,5 +204,7 @@ int main() {
     RUN_TEST(test_accept_env_false);
     RUN_TEST(test_fallback_local_ip_true);
     RUN_TEST(test_fallback_local_ip_false);
+    RUN_TEST(test_disable_ca_pinning_true);
+    RUN_TEST(test_disable_ca_pinning_false);
     return UNITY_END();
 }


### PR DESCRIPTION
## Description
- Added `disable_ca_pinning` configuration option to login_duo and pam_duo
- When enabled, TLS connections validate against the OS trust store (`SSL_CTX_set_default_verify_paths`) instead of Duo's bundled CA certificates
- TLS verification (`SSL_VERIFY_PEER`) remains enforced — disabling pinning does not disable TLS
- Default: CA pinning enabled (existing behavior unchanged)
- Setting is admin-privileged via existing config file permission model (root-only readable)

## How Has This Been Tested?
- `test_disable_ca_pinning_true` — verifies config parser sets `disable_ca_pinning = 1` when value is `"true"`
- `test_disable_ca_pinning_false` — verifies config parser sets `disable_ca_pinning = 0` when value is `"false"`
- Verified default behavior unchanged: without `disable_ca_pinning` in config, connections use pinned CA bundle
- Verified `noverify` takes precedence over `disable_ca_pinning`
- Tested with both login_duo and pam_duo

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)