### PR TITLE
Scrub DUO_PASSCODE from environment before exec'ing user shell

### DIFF
--- a/lib/duo.c
+++ b/lib/duo.c
@@ -537,6 +537,8 @@ _duo_prompt(struct duo_ctx *ctx, int flags, char *buf,
         if (strlcpy(p, passcode, sp) >= sp) {
             return (DUO_LIB_ERROR);
         }
+        OPENSSL_cleanse(passcode, strlen(passcode));
+        unsetenv(DUO_ENV_VAR_NAME);
         if (ctx->conv_status != NULL) {
             ctx->conv_status(ctx->conv_arg, ENV_VAR_MSG);
         }

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -355,6 +355,8 @@ do_exec(struct login_ctx *ctx, const char *cmd)
     const char *user_shell;
     int n;
 
+    unsetenv(DUO_ENV_VAR_NAME);
+
     if ((pw = getpwuid(ctx->uid)) == NULL) {
         die("Who are you?");
     }

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -341,6 +341,28 @@ class TestLoginDuoSpecificEnv(CommonTestCase):
             )
             self.assertEqual(process.expect("SUCCESS", timeout=10), 0)
 
+    def test_env_factor_scrubbed_from_child(self):
+        """DUO_PASSCODE must not leak into the exec'd command's environment."""
+        config = DuoUnixConfig(
+            ikey="DIXYZV6YM8IFYVWBINCA",
+            skey="yWHSMhWucAcp7qvuH3HWTaSaKABs8Gaddiv1NIRo",
+            host="localhost:4443",
+            cafile="certs/mockduo-ca.pem",
+            accept_env_factor="yes",
+        )
+
+        with TempConfig(config) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "whatever"],
+                env={
+                    "UID": "1001",
+                    "DUO_PASSCODE": "push1",
+                    "SSH_ORIGINAL_COMMAND": "echo DUO_PASSCODE=${DUO_PASSCODE:-UNSET}",
+                },
+                preload_script=os.path.join(TESTDIR, "login_duo.py"),
+            )
+            self.assertIn("DUO_PASSCODE=UNSET", result["stdout"])
+
 
 class TestLoginDuoUIDMismatch(CommonTestCase):
     def run(self, result=None):


### PR DESCRIPTION
## Summary of the change
When accept_env_factor is enabled, login_duo reads DUO_PASSCODE from the environment but never cleared it before execl(). This left the value readable in the child process tree via /proc/<pid>/environ — a problem for reusable bypass codes on shared-UID accounts.

Fix: unsetenv(DUO_ENV_VAR_NAME) in do_exec() before execl(), and OPENSSL_cleanse + unsetenv in _duo_prompt() immediately after copying the value so it doesn't linger during authentication either.

## Test Plan
New and existing tests should pass
