### PR TITLE
Complete skey zeroization across all residual paths

### DIFF
--- a/lib/duo.c
+++ b/lib/duo.c
@@ -135,6 +135,10 @@ duo_parse_config(const char *filename,
         fclose(fp);
         return (-2);
     }
+    if (setvbuf(fp, NULL, _IONBF, 0) != 0) {
+        fclose(fp);
+        return (-3);
+    }
     ret = ini_parse(fp, callback, arg);
     fclose(fp);
     return (ret);

--- a/lib/duo.h
+++ b/lib/duo.h
@@ -34,7 +34,15 @@ typedef enum {
 
 typedef struct duo_ctx duo_t;
 
-/* Parse INI config file */
+/*
+ * Parse INI config file. Returns:
+ *    0  success
+ *   >0  parse error, value is the offending line number
+ *   -1  could not open the file
+ *   -2  file is group- or world-readable (must be readable only by owner)
+ *   -3  could not disable stdio buffering (fail closed; a buffered read
+ *       could leave secret material in an unscrubbed heap buffer)
+ */
 int duo_parse_config(
     const char *filename,
     int (*callback)(void *arg, const char *section, const char *name, const char *val),

--- a/lib/ini.c
+++ b/lib/ini.c
@@ -13,6 +13,8 @@ http://code.google.com/p/inih/
 
 */
 
+#include "config.h"
+
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
@@ -143,5 +145,13 @@ int ini_parse(FILE *file,
         }
     }
 
+#ifdef HAVE_EXPLICIT_BZERO
+    explicit_bzero(line, sizeof(line));
+#else
+    {
+        static void* (* volatile ini_memset)(void *, int, size_t) = memset;
+        ini_memset(line, 0, sizeof(line));
+    }
+#endif
     return error;
 }

--- a/lib/util.c
+++ b/lib/util.c
@@ -213,24 +213,25 @@ close_config(struct duo_config *cfg)
     if (cfg == NULL) {
         return;
     }
+    /* Zero strlen + 1 to include the NUL terminator, matching duo_close(). */
     if (cfg->ikey != NULL) {
-        duo_zero_free(cfg->ikey, strlen(cfg->ikey));
+        duo_zero_free(cfg->ikey, strlen(cfg->ikey) + 1);
         cfg->ikey = NULL;
     }
     if (cfg->skey != NULL) {
-        duo_zero_free(cfg->skey, strlen(cfg->skey));
+        duo_zero_free(cfg->skey, strlen(cfg->skey) + 1);
         cfg->skey = NULL;
     }
     if (cfg->apihost != NULL) {
-        duo_zero_free(cfg->apihost, strlen(cfg->apihost));
+        duo_zero_free(cfg->apihost, strlen(cfg->apihost) + 1);
         cfg->apihost = NULL;
     }
     if (cfg->cafile != NULL) {
-        duo_zero_free(cfg->cafile, strlen(cfg->cafile));
+        duo_zero_free(cfg->cafile, strlen(cfg->cafile) + 1);
         cfg->cafile = NULL;
     }
     if (cfg->http_proxy != NULL) {
-        duo_zero_free(cfg->http_proxy, strlen(cfg->http_proxy));
+        duo_zero_free(cfg->http_proxy, strlen(cfg->http_proxy) + 1);
         cfg->http_proxy = NULL;
     }
     cleanup_config_groups(cfg);

--- a/lib/util.c
+++ b/lib/util.c
@@ -53,15 +53,50 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
     const char *name, const char*val)
 {
     if (strcmp(name, "ikey") == 0) {
-        cfg->ikey = strdup(val);
+        char *new_val = strdup(val);
+        if (new_val == NULL) {
+            return (0);
+        }
+        if (cfg->ikey != NULL) {
+            duo_zero_free(cfg->ikey, strlen(cfg->ikey));
+        }
+        cfg->ikey = new_val;
     } else if (strcmp(name, "skey") == 0) {
-        cfg->skey = strdup(val);
+        char *new_val = strdup(val);
+        if (new_val == NULL) {
+            return (0);
+        }
+        if (cfg->skey != NULL) {
+            duo_zero_free(cfg->skey, strlen(cfg->skey));
+        }
+        cfg->skey = new_val;
     } else if (strcmp(name, "host") == 0) {
-        cfg->apihost = strdup(val);
+        char *new_val = strdup(val);
+        if (new_val == NULL) {
+            return (0);
+        }
+        if (cfg->apihost != NULL) {
+            duo_zero_free(cfg->apihost, strlen(cfg->apihost));
+        }
+        cfg->apihost = new_val;
     } else if (strcmp(name, "cafile") == 0) {
-        cfg->cafile = strdup(val);
+        char *new_val = strdup(val);
+        if (new_val == NULL) {
+            return (0);
+        }
+        if (cfg->cafile != NULL) {
+            duo_zero_free(cfg->cafile, strlen(cfg->cafile));
+        }
+        cfg->cafile = new_val;
     } else if (strcmp(name, "http_proxy") == 0) {
-        cfg->http_proxy = strdup(val);
+        char *new_val = strdup(val);
+        if (new_val == NULL) {
+            return (0);
+        }
+        if (cfg->http_proxy != NULL) {
+            duo_zero_free(cfg->http_proxy, strlen(cfg->http_proxy));
+        }
+        cfg->http_proxy = new_val;
     } else if (strcmp(name, "groups") == 0 || strcmp(name, "group") == 0) {
         size_t len = strlen(val);
         size_t i = 0, j = 0;

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -153,8 +153,14 @@ do_auth(struct login_ctx *ctx, const char *cmd)
 
     /* Load our private config. */
     i = duo_parse_config(config, __ini_handler, &cfg);
+    if (i == -3) {
+        close_config(&cfg);
+        fprintf(stderr, "Internal error reading %s\n", config);
+        return (EXIT_FAILURE);
+    }
     if (i != 0 || !cfg.apihost || !cfg.apihost[0] || !cfg.skey || !cfg.skey[0] ||
         !cfg.ikey || !cfg.ikey[0] || (cfg.autopush && cfg.verified_push)) {
+        int failmode = cfg.failmode;
         switch (i) {
         case -2:
             fprintf(stderr, "%s must be readable only by "
@@ -176,8 +182,8 @@ do_auth(struct login_ctx *ctx, const char *cmd)
             fprintf(stderr, "Parse error in %s, line %d\n", config, i);
             break;
         }
-        /* Implicit "safe" failmode for local configuration errors */
-        if (cfg.failmode == DUO_FAIL_SAFE) {
+        close_config(&cfg);
+        if (failmode == DUO_FAIL_SAFE) {
             return (EXIT_SUCCESS);
         }
         return (EXIT_FAILURE);

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -150,24 +150,38 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
     }
 
     i = duo_parse_config(config, __ini_handler, &cfg);
-    if (i == -2) {
+    if (i == -3) {
+        close_config(&cfg);
+        duo_syslog(LOG_ERR, "Internal error reading %s", config);
+        return (PAM_SERVICE_ERR);
+    } else if (i == -2) {
+        int failmode = cfg.failmode;
         duo_syslog(LOG_ERR, "%s must be readable only by user 'root'",
             config);
-        return (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+        close_config(&cfg);
+        return (failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
     } else if (i == -1) {
+        int failmode = cfg.failmode;
         duo_syslog(LOG_ERR, "Couldn't open %s: %s",
             config, strerror(errno));
-        return (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+        close_config(&cfg);
+        return (failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
     } else if (i > 0) {
+        int failmode = cfg.failmode;
         duo_syslog(LOG_ERR, "Parse error in %s, line %d", config, i);
-        return (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+        close_config(&cfg);
+        return (failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
     } else if (!cfg.apihost || !cfg.apihost[0] ||
             !cfg.skey || !cfg.skey[0] || !cfg.ikey || !cfg.ikey[0]) {
+        int failmode = cfg.failmode;
         duo_syslog(LOG_ERR, "Missing host, ikey, or skey in %s", config);
-        return (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+        close_config(&cfg);
+        return (failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
     } else if (cfg.autopush && cfg.verified_push) {
+        int failmode = cfg.failmode;
         duo_syslog(LOG_ERR, "autopush and verified_push cannot both be enabled in %s", config);
-        return (cfg.failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
+        close_config(&cfg);
+        return (failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
     }
 
     /* Check user */


### PR DESCRIPTION
## Summary of the change
The existing duo_zero_free() scrub of cfg->skey was being defeated by three code paths that left the plaintext secret in process memory:

1. stdio internal buffer: duo_parse_config() used buffered I/O, so fgets() left the raw skey line in a heap buffer freed without zeroing by fclose(). Fix: setvbuf(fp, NULL, _IONBF, 0) before reading, fail closed if setvbuf cannot disable buffering.

2. Error-path leaks: pam_sm_authenticate() and do_auth() returned on config errors without calling close_config(), leaking any already- parsed skey. Fix: call close_config(&cfg) on every error return.

3. Parser stack buffer: ini_parse() left the last-read line (possibly the skey line) in a stack buffer. Fix: explicit_bzero the line buffer before returning.

4. Duplicate key handling: duo_common_ini_handler() overwrote pointer fields without freeing the previous allocation. Fix: duo_zero_free existing values before strdup of new ones.


## Test Plan
Tests should pass
