### PR TITLE
Fix TLS fail-open on NULL peer certificate and restrict cipher suites

### DIFF
--- a/lib/https.c
+++ b/lib/https.c
@@ -216,9 +216,11 @@ _SSL_check_server_cert(SSL *ssl, const char *hostname)
     int hostnametype = GEN_DNS;
     size_t addrsize;
 
-    if (SSL_get_verify_mode(ssl) == SSL_VERIFY_NONE ||
-        (cert = SSL_get_peer_certificate(ssl)) == NULL) {
+    if (SSL_get_verify_mode(ssl) == SSL_VERIFY_NONE) {
         return (1);
+    }
+    if ((cert = SSL_get_peer_certificate(ssl)) == NULL) {
+        return (0);
     }
 
     /* Check if hostname is an IP address */
@@ -706,6 +708,10 @@ https_init(const char *cafile, const char *http_proxy)
     /* Blacklist SSLv23 */
     const long blacklist = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
     SSL_CTX_set_options(ctx.ssl_ctx, blacklist);
+    /* Exclude anonymous and null-encryption ciphers for TLS 1.2 and below.
+       Failure is non-fatal: on TLS 1.3-only builds no 1.2 ciphers exist,
+       and TLS 1.3 has no aNULL suites. */
+    SSL_CTX_set_cipher_list(ctx.ssl_ctx, "DEFAULT:!aNULL:!eNULL");
     /* Set up our CA cert */
     if (cafile == NULL) {
         /* Load default CA cert from memory */

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -421,20 +421,31 @@ class HTTPServerV6(HTTPServer):
 def main():
     port = 4443
     host = "::"
-    if len(sys.argv) == 1:
+    anull = False
+
+    args = sys.argv[1:]
+    if "--anull" in args:
+        anull = True
+        args.remove("--anull")
+
+    if len(args) == 0:
         cafile = os.path.realpath(
             "{0}/certs/mockduo.pem".format(os.path.dirname(__file__))
         )
-    elif len(sys.argv) == 2:
-        cafile = sys.argv[1]
+    elif len(args) == 1:
+        cafile = args[0]
     else:
-        print("Usage: {0} [certfile]\n".format(sys.argv[0]), file=sys.stderr)
+        print("Usage: {0} [--anull] [certfile]\n".format(sys.argv[0]), file=sys.stderr)
         sys.exit(1)
 
     httpd = HTTPServerV6((host, port), MockDuoHandler)
 
     ctx = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_SERVER)
-    ctx.load_cert_chain(cafile)
+    if anull:
+        ctx.set_ciphers("ADH:@SECLEVEL=0")
+        ctx.maximum_version = ssl.TLSVersion.TLSv1_2
+    else:
+        ctx.load_cert_chain(cafile)
     httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
 
     httpd.serve_forever()

--- a/tests/mockduo_context.py
+++ b/tests/mockduo_context.py
@@ -70,9 +70,13 @@ class MockDuoTimeoutException(MockDuoException):
 
 
 class MockDuo:
-    def __init__(self, cert=NORMAL_CERT):
+    def __init__(self, cert=NORMAL_CERT, anull=False):
         self.cert = cert
-        self.cmd = ["python3", os.path.join(TESTDIR, "mockduo.py"), self.cert]
+        self.cmd = ["python3", os.path.join(TESTDIR, "mockduo.py")]
+        if anull:
+            self.cmd.append("--anull")
+        else:
+            self.cmd.append(self.cert)
         self.process = None
 
     def __enter__(self):

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -188,6 +188,32 @@ class TestLoginDuoBadCN(CommonSuites.DuoBadCN):
         return login_duo(*args)
 
 
+class TestLoginDuoAnonCipher(CommonTestCase):
+    """A server offering only anonymous ciphers (no certificate) must be rejected."""
+
+    def run(self, result=None):
+        with MockDuo(anull=True):
+            return super(TestLoginDuoAnonCipher, self).run(result)
+
+    def test_anull_rejected(self):
+        config = DuoUnixConfig(
+            ikey="DIXYZV6YM8IFYVWBINCA",
+            skey="yWHSMhWucAcp7qvuH3HWTaSaKABs8Gaddiv1NIRo",
+            host="localhost:4443",
+            cafile="certs/mockduo-ca.pem",
+            failmode="secure",
+        )
+        with TempConfig(config) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "whatever", "true"]
+            )
+            self.assertEqual(result["returncode"], 1)
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Couldn't connect to",
+            )
+
+
 class TestMockDuoWithValidCert(CommonSuites.WithValidCert):
     def call_binary(self, *args):
         return login_duo(*args)


### PR DESCRIPTION
## Summary of the change

_SSL_check_server_cert() returned success when SSL_get_peer_certificate() was NULL even with SSL_VERIFY_PEER active. On platforms whose OpenSSL default cipher string includes anonymous (aNULL) suites, an on-path attacker could complete a certificate-less handshake and inject forged Duo API responses to bypass 2FA.

Two fixes:
1. Split the verify-mode/cert-null condition: return failure (0) when verify mode is not NONE but no peer certificate was presented.
2. Set an explicit cipher list (DEFAULT:!aNULL:!eNULL) after SSL_CTX_new() so anonymous and null-encryption suites are never offered regardless of the platform's openssl.cnf defaults. Non-fatal since TLS 1.3-only builds have no 1.2 ciphers and no aNULL risk.

## Test Plan
New and existing tests should pass
