### PR TITLE
Recognize IPv6 literals in client address parsing

### DIFF
--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -131,6 +131,7 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     struct duo_config cfg;
     struct passwd *pw;
     struct in_addr addr;
+    struct in6_addr addr6;
     duo_t *duo;
     duo_code_t code;
     const char *config, *p, *duouser;
@@ -225,13 +226,22 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     }
 
     /* Check for remote login host */
-    if ((host = ip = getenv("SSH_CONNECTION")) != NULL ||
-        (host = ip = (char *)ctx->host) != NULL) {
-        if (inet_aton(ip, &addr)) {
-            strlcpy(buf, ip, sizeof(buf));
-            ip = strtok(buf, " ");
-            host = ip;
-        } else {
+    if ((host = ip = getenv("SSH_CONNECTION")) != NULL) {
+        strlcpy(buf, ip, sizeof(buf));
+        ip = strtok(buf, " ");
+        if (ip == NULL) {
+            ip = "";
+        }
+        host = ip;
+        if (!inet_aton(ip, &addr) &&
+            inet_pton(AF_INET6, ip, &addr6) != 1) {
+            if (cfg.local_ip_fallback) {
+                host = duo_local_ip();
+            }
+        }
+    } else if ((host = ip = (char *)ctx->host) != NULL) {
+        if (!inet_aton(ip, &addr) &&
+            inet_pton(AF_INET6, ip, &addr6) != 1) {
             if (cfg.local_ip_fallback) {
                 host = duo_local_ip();
             }

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -124,6 +124,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
     struct duo_config cfg;
     struct passwd *pw;
     struct in_addr addr;
+    struct in6_addr addr6;
     duo_t *duo;
     duo_code_t code;
 
@@ -241,8 +242,9 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
     if (ip == NULL) {
         ip = ""; /* XXX inet_addr needs a non-null IP */
     }
-    if (!inet_aton(ip, &addr)) {
-        /* We have a hostname, don't try to resolve, check fallback */
+    if (!inet_aton(ip, &addr) &&
+        inet_pton(AF_INET6, ip, &addr6) != 1) {
+        /* Not an IPv4 or IPv6 literal — likely a hostname, check fallback */
         if (cfg.local_ip_fallback) {
             host = duo_local_ip();
         }

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -21,6 +21,7 @@ from config import (
     MOCKDUO_ADMINS_NO_USERS,
     MOCKDUO_AUTOPUSH,
     MOCKDUO_CONF,
+    MOCKDUO_FALLBACK,
     MOCKDUO_GECOS_DEFAULT_DELIM_6_POS,
     MOCKDUO_GECOS_DEPRECATED_PARSE_FLAG,
     MOCKDUO_GECOS_INVALID_DELIM_COLON,
@@ -861,6 +862,46 @@ class TestLoginDuoTimeSync(CommonSuites.DuoTimeSync):
 class TestLoginDuoVerifiedPush(CommonSuites.VerifiedPush):
     def call_binary(self, *args, **kwargs):
         return login_duo(*args, **kwargs)
+
+class TestLoginDuoIPv6(CommonTestCase):
+    def run(self, result=None):
+        with MockDuo(NORMAL_CERT):
+            return super(TestLoginDuoIPv6, self).run(result)
+
+    def test_ipv6_ssh_connection_not_replaced_by_fallback(self):
+        """IPv6 client address in SSH_CONNECTION must be sent as-is, not replaced by duo_local_ip()"""
+        with TempConfig(MOCKDUO_FALLBACK) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
+                env={
+                    "SSH_CONNECTION": "::1 50310 ::1 22",
+                    "FALLBACK": "1",
+                    "UID": "1001",
+                },
+                preload_script=os.path.join(TESTDIR, "login_duo.py"),
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Skipped Duo login for 'preauth-allow' from ::1",
+            )
+
+    def test_hostname_ssh_connection_still_triggers_fallback(self):
+        """Non-IP hostname in SSH_CONNECTION should still trigger duo_local_ip() fallback"""
+        with TempConfig(MOCKDUO_FALLBACK) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
+                env={
+                    "SSH_CONNECTION": "badhost.example.com 50310 server 22",
+                    "FALLBACK": "1",
+                    "UID": "1001",
+                },
+                preload_script=os.path.join(TESTDIR, "login_duo.py"),
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Skipped Duo login for 'preauth-allow' from 1\.2\.3\.4",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -19,6 +19,7 @@ import pexpect
 from common_suites import NORMAL_CERT, CommonSuites, EOF, CommonTestCase
 from config import (
     MOCKDUO_CONF,
+    MOCKDUO_FALLBACK,
     MOCKDUO_GECOS_DEFAULT_DELIM_6_POS,
     MOCKDUO_GECOS_DEPRECATED_PARSE_FLAG,
     MOCKDUO_GECOS_INVALID_DELIM_COLON,
@@ -490,6 +491,41 @@ class TestPamGECOS(CommonTestCase):
                 ["-d", "-c", temp.name, "-f", "emptygecos"],
             )
             self.assertEqual(process.expect("Empty GECOS field"), 0)
+
+
+@unittest.skipIf(sys.platform == "sunos5", SOLARIS_ISSUE)
+class TestPamDuoIPv6(CommonTestCase):
+    def run(self, result=None):
+        with MockDuo(NORMAL_CERT):
+            return super(TestPamDuoIPv6, self).run(result)
+
+    def test_ipv6_rhost_not_replaced_by_fallback(self):
+        """IPv6 PAM_RHOST must be sent as-is, not replaced by duo_local_ip()"""
+        with TempConfig(MOCKDUO_FALLBACK) as temp:
+            result = pam_duo(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "-h", "::1"],
+                env={
+                    "FALLBACK": "1",
+                },
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Skipped Duo login for 'preauth-allow' from ::1",
+            )
+
+    def test_hostname_rhost_still_triggers_fallback(self):
+        """Non-IP PAM_RHOST should still trigger duo_local_ip() fallback"""
+        with TempConfig(MOCKDUO_FALLBACK) as temp:
+            result = pam_duo(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "-h", "badhost.example.com"],
+                env={
+                    "FALLBACK": "1",
+                },
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Skipped Duo login for 'preauth-allow' from 1\.2\.3\.4",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary of the change

login_duo and pam_duo used inet_aton() to validate remote addresses, which only accepts IPv4 dotted-quad. IPv6 literals were misclassified as hostnames, causing fallback_local_ip to substitute the server's own address. Add inet_pton(AF_INET6) as a second check so IPv6 addresses are passed through unchanged.

## Test Plan
New and existing tests should pass
