### PR TITLE
Use parser error code, not byte count, for HTTP parse failures

### DIFF
--- a/lib/https.c
+++ b/lib/https.c
@@ -1048,7 +1048,11 @@ https_recv(struct https_request *req, int *code, const char **body, int *len,
         }
         if ((err = http_parser_execute(req->parser,
                     &ctx.parse_settings, ctx.parse_buf, n)) != n) {
-            ctx.errstr = http_errno_description(err);
+            /* http_parser_execute() returns the count of bytes consumed, not
+               an error code; on a parse failure that is the offset of the
+               failing byte. Read the actual error code from the parser so we
+               don't index http_errno_description()'s table out of bounds. */
+            ctx.errstr = http_errno_description(HTTP_PARSER_ERRNO(req->parser));
             return (HTTPS_ERR_SERVER);
         }
     }

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -69,6 +69,18 @@ class MockDuoHandler(BaseHTTPRequestHandler):
     _skew_permanent = 0
     _skew_once = None
 
+    # When set, every response is a raw HTTP reply whose first invalid byte
+    # sits at a byte offset well past the http_errno description table, used
+    # to exercise the client's handling of unparseable server responses.
+    _malformed = False
+
+    def _send_malformed(self):
+        # The '(' is not a valid header-name token character; placing it at
+        # offset 37 makes the HTTP parser report that offset as its consumed
+        # byte count, which a naive client may mistake for an error code.
+        raw = b"HTTP/1.1 200 OK\r\n" + b"A" * 20 + b"(" + b": x\r\n\r\n"
+        self.wfile.write(raw)
+
     def __init__(self, *args, **kwargs):
         self._rl_req_clock = 0
         self._rl_req_num = 0
@@ -202,6 +214,8 @@ class MockDuoHandler(BaseHTTPRequestHandler):
         ret = {"stat": "OK"}
 
         if self.path == "/auth/v2/ping":
+            if type(self)._malformed:
+                return self._send_malformed()
             skew = self._get_skew()
             ret["response"] = {"time": int(time.time()) + skew}
             buf = json.dumps(ret)
@@ -427,6 +441,9 @@ def main():
     if "--anull" in args:
         anull = True
         args.remove("--anull")
+    if "--malformed" in args:
+        MockDuoHandler._malformed = True
+        args.remove("--malformed")
 
     if len(args) == 0:
         cafile = os.path.realpath(
@@ -435,7 +452,7 @@ def main():
     elif len(args) == 1:
         cafile = args[0]
     else:
-        print("Usage: {0} [--anull] [certfile]\n".format(sys.argv[0]), file=sys.stderr)
+        print("Usage: {0} [--anull] [--malformed] [certfile]\n".format(sys.argv[0]), file=sys.stderr)
         sys.exit(1)
 
     httpd = HTTPServerV6((host, port), MockDuoHandler)

--- a/tests/mockduo_context.py
+++ b/tests/mockduo_context.py
@@ -70,9 +70,11 @@ class MockDuoTimeoutException(MockDuoException):
 
 
 class MockDuo:
-    def __init__(self, cert=NORMAL_CERT, anull=False):
+    def __init__(self, cert=NORMAL_CERT, anull=False, malformed=False):
         self.cert = cert
         self.cmd = ["python3", os.path.join(TESTDIR, "mockduo.py")]
+        if malformed:
+            self.cmd.append("--malformed")
         if anull:
             self.cmd.append("--anull")
         else:

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -21,6 +21,7 @@ from config import (
     MOCKDUO_ADMINS_NO_USERS,
     MOCKDUO_AUTOPUSH,
     MOCKDUO_CONF,
+    MOCKDUO_FAILSECURE,
     MOCKDUO_FALLBACK,
     MOCKDUO_GECOS_DEFAULT_DELIM_6_POS,
     MOCKDUO_GECOS_DEPRECATED_PARSE_FLAG,
@@ -949,6 +950,37 @@ class TestLoginDuoIPv6(CommonTestCase):
                 result["stderr"],
                 r"Skipped Duo login for 'preauth-allow' from 1\.2\.3\.4",
             )
+
+
+class TestLoginDuoMalformedResponse(unittest.TestCase):
+    """A server response that fails to parse must not crash the process.
+
+    The failing byte's offset was previously passed to the error-description
+    lookup as if it were an error code, aborting (assert build) or reading out
+    of bounds (NDEBUG build). The process should instead handle the parse
+    failure and fall through to failmode. Run login_duo directly (no preload
+    wrapper) so a signal death surfaces as a negative returncode.
+    """
+
+    def run_malformed(self, config):
+        with MockDuo(NORMAL_CERT, malformed=True):
+            with TempConfig(config) as temp:
+                return login_duo(
+                    ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
+                )
+
+    def test_malformed_response_failsafe(self):
+        result = self.run_malformed(MOCKDUO_CONF)
+        # A negative returncode means death by signal (e.g. SIGABRT).
+        self.assertGreaterEqual(result["returncode"], 0)
+        # failmode safe => login allowed despite the server error
+        self.assertEqual(result["returncode"], 0)
+
+    def test_malformed_response_failsecure(self):
+        result = self.run_malformed(MOCKDUO_FAILSECURE)
+        self.assertGreaterEqual(result["returncode"], 0)
+        # failmode secure => login denied, but cleanly (no crash)
+        self.assertEqual(result["returncode"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary of the change

https_recv() passed the return value of http_parser_execute() to http_errno_description(). That return value is the count of bytes consumed (on a parse failure, the offset of the failing byte), not an error code, so a server-controlled offset could index the 31-entry description table out of bounds. Read the real error code with HTTP_PARSER_ERRNO() instead.

Add a --malformed mode to the mock server and tests that drive login_duo against an unparseable response, confirming it handles the error through failmode instead of aborting.

## Test Plan
New and existing tests should pass