### PR TITLE
Warn that GECOS-derived Duo usernames are user-controlled

### DIFF
--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -208,7 +208,19 @@ do_auth(struct login_ctx *ctx, const char *cmd)
         return (EXIT_SUCCESS);
     }
 
-    /* Use GECOS field if called for */
+    /*
+     * Use GECOS field if called for.
+     *
+     * SECURITY NOTE: the GECOS field is user-controlled data. On most
+     * systems chfn(1) lets an unprivileged user edit their own GECOS
+     * sub-fields (subject to CHFN_RESTRICT in login.defs), so send_gecos
+     * and gecos_username_pos let a user choose the Duo identity presented
+     * for their own second-factor challenge, decoupling it from the OS
+     * identity that primary auth established. These options are deprecated
+     * in favor of Duo username aliases; administrators enabling them must
+     * restrict chfn. We log both identities below so a substitution is
+     * visible in host audit logs.
+     */
     if ((cfg.send_gecos || cfg.gecos_username_pos >= 0) && !ctx->duouser) {
         if (strlen(pw->pw_gecos) > 0) {
             if (cfg.gecos_username_pos >= 0) {
@@ -219,6 +231,14 @@ do_auth(struct login_ctx *ctx, const char *cmd)
                 }
             } else {
                 duouser = pw->pw_gecos;
+            }
+            if (strcmp(duouser, pw->pw_name) != 0) {
+                /* duo_log() sanitizes the assembled message; the
+                   GECOS-derived name is user-controlled, so it must not go
+                   to syslog unsanitized. Logs as:
+                   "... for '<os user>': <gecos-derived duo username>" */
+                duo_log(LOG_INFO, "Presenting GECOS-derived Duo username",
+                    pw->pw_name, NULL, duouser);
             }
         } else {
             duo_log(LOG_WARNING, "Empty GECOS field", pw->pw_name, NULL, NULL);

--- a/pam_duo/pam_duo.8
+++ b/pam_duo/pam_duo.8
@@ -70,6 +70,23 @@ IP. Default is "no".
 .It Cm send_gecos
 Instead of using the unix username, send Duo the contents of the GECOS field
 from /etc/passwd.  Default is "no".
+.Pp
+.Sy Warning:
+the GECOS field is not a trusted attribute.  On most systems
+.Xr chfn 1
+lets an unprivileged user edit their own GECOS field (subject to
+.Cm CHFN_RESTRICT
+in
+.Xr login.defs 5 ) ,
+so enabling this option lets a user choose the Duo identity presented for
+their own second-factor challenge, decoupling it from the operating-system
+identity established by primary authentication.  This option is deprecated in
+favor of Duo username aliases, which are stored server-side and cannot be
+edited by the end user.  If you must enable it, first restrict
+.Xr chfn 1
+(for example by setting
+.Cm CHFN_RESTRICT
+to deny the fields used, or by removing its setuid bit).
 .El
 .Pp
 An example configuration file:

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -216,7 +216,19 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
         return (PAM_SUCCESS);
     }
 
-    /* Use GECOS field if called for */
+    /*
+     * Use GECOS field if called for.
+     *
+     * SECURITY NOTE: the GECOS field is user-controlled data. On most
+     * systems chfn(1) lets an unprivileged user edit their own GECOS
+     * sub-fields (subject to CHFN_RESTRICT in login.defs), so send_gecos
+     * and gecos_username_pos let a user choose the Duo identity presented
+     * for their own second-factor challenge, decoupling it from the OS
+     * identity that primary auth established. These options are deprecated
+     * in favor of Duo username aliases; administrators enabling them must
+     * restrict chfn. We log both identities below so a substitution is
+     * visible in host audit logs.
+     */
     if (cfg.send_gecos || cfg.gecos_username_pos >= 0) {
         if (strlen(pw->pw_gecos) > 0) {
             if (cfg.gecos_username_pos >= 0) {
@@ -227,6 +239,14 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
                 }
             } else {
                 user = pw->pw_gecos;
+            }
+            if (strcmp(user, pw->pw_name) != 0) {
+                /* duo_log() sanitizes the assembled message; the
+                   GECOS-derived name is user-controlled, so it must not go
+                   to syslog unsanitized. Logs as:
+                   "... for '<os user>': <gecos-derived duo username>" */
+                duo_log(LOG_INFO, "Presenting GECOS-derived Duo username",
+                    pw->pw_name, NULL, user);
             }
         } else {
             duo_log(LOG_WARNING, "Empty GECOS field", pw->pw_name, NULL, NULL);


### PR DESCRIPTION
## Summary of the change

The GECOS field is editable by unprivileged users via chfn on most systems, so send_gecos and gecos_username_pos let a user choose the Duo identity used for their own second-factor challenge. Document the risk in pam_duo.8, add a code comment at both mapping sites, and log both the OS username and the GECOS-derived Duo username (via the sanitizing duo_log path) when they differ so a substitution is visible in host audit logs.

## Test Plan
Tests should pass
