### PR TITLE
Set restrictive umask in support bundle collector

### DIFF
--- a/duo_unix_support/duo_unix_support.sh
+++ b/duo_unix_support/duo_unix_support.sh
@@ -48,6 +48,14 @@ if [ $(id -u) != 0 ]; then
     echo "Please rerun as root"
     exit
 fi
+
+# Create every file and directory this script produces (staging dir,
+# configuration.txt, scrubbed confs, tarball) with restrictive perms so
+# they are never world- or group-readable during creation. The later
+# chmod calls then only tighten, closing the window where a local user
+# could open the world-readable tarball before it is restricted.
+umask 077
+
 # If there is an existing support file or tarball then delete them
 if [ -d '/etc/duo/duo_unix_support' ]; then
     rm -rf /etc/duo/duo_unix_support


### PR DESCRIPTION
## Summary of the change

The support script created its staging directory, scrubbed config copies, and the final tarball under the caller's default umask (typically 022), leaving them world-readable until a later chmod. A local user could open the tarball during that window and read the root-only logs it bundles. Set umask 077 before any file or directory is created so they are never group- or world-accessible; the existing chmod calls now only tighten.

## Test Plan
Tests should pass
