### PR TITLE
Bound the 429 retry loop against a hostile Retry-After

### DIFF
--- a/lib/duo.c
+++ b/lib/duo.c
@@ -365,10 +365,19 @@ _duo_https_exchange(struct duo_ctx *ctx, const char *method, const char *uri, in
     const int max_backoff_wait_secs = 32;
     const int initial_backof_wait_secs = 1;
     const int backoff_factor = 2;
+    /* Hard cap on 429 retries. A malicious or misbehaving server that
+       answers every request with 429 and an in-range Retry-After header
+       could otherwise pin us in the loop forever, since the header
+       overwrites wait_secs each iteration and defeats the backoff-based
+       exit. Bounding the iteration count guarantees we return so the
+       caller can apply failmode. Six matches the no-header backoff
+       schedule (1,2,4,8,16,32). */
+    const int max_retries = 6;
 
     static const char fmt[] = "Rate-limiting response received from server. Waiting for %ld seconds before retrying.";
     char msg[(sizeof fmt) + max_int_digits];
     int wait_secs = initial_backof_wait_secs;
+    int retries = 0;
 
     while (1) {
         HTTPScode rc;
@@ -380,12 +389,38 @@ _duo_https_exchange(struct duo_ctx *ctx, const char *method, const char *uri, in
         if (rc != HTTPS_OK)
             return rc;
         rc = https_recv(ctx->https, code, &ctx->body, &ctx->body_len, &retry_after, msecs);
-        if (retry_after != (time_t)-1)
-            wait_secs = retry_after - time(NULL);
+
+        if (retry_after == DUO_RETRY_AFTER_INVALID) {
+            /* Header present but unusable (negative, out of range, past-dated,
+               or malformed). Treat it as terminal rather than as license to
+               back off: push wait_secs past the ceiling so the exit below
+               fires and failmode is applied. A hostile server must not be
+               able to buy extra retries by sending an implausible value. */
+            wait_secs = max_backoff_wait_secs + 1;
+        } else if (retry_after != DUO_RETRY_AFTER_NONE) {
+            /* Usable deadline. Compute the delay in time_t and clamp it into
+               the backoff band *before* narrowing to int, so a far-future
+               deadline cannot wrap to a small or negative int and slip past
+               the ceiling test (C11 6.3.1.3p3). */
+            time_t delay = retry_after - time(NULL);
+            if (delay < initial_backof_wait_secs)
+                delay = initial_backof_wait_secs;
+            else if (delay > max_backoff_wait_secs)
+                delay = max_backoff_wait_secs + 1;
+            wait_secs = (int)delay;
+        }
 
         if (rc != HTTPS_OK || *code != 429 || wait_secs > max_backoff_wait_secs)
             return rc;
 
+        /* Return once the retry cap is hit so failmode can be applied. */
+        if (++retries > max_retries)
+            return rc;
+
+        /* wait_secs is in [initial_backof_wait_secs, max_backoff_wait_secs]
+           here: the header-present branch clamped it and the header-absent
+           backoff never goes below the initial wait, so nanosleep() cannot
+           get a negative tv_sec and spin. */
         struct timespec timeout = {
             .tv_sec = wait_secs,
             .tv_nsec = (float)rand() / RAND_MAX * 1000000000
@@ -395,7 +430,9 @@ _duo_https_exchange(struct duo_ctx *ctx, const char *method, const char *uri, in
         if (ctx->conv_status)
             ctx->conv_status(NULL, msg);
         nanosleep(&timeout, NULL);
-        if (retry_after == (time_t)-1)
+        /* Only an absent header enables exponential backoff; a usable header
+           sets the wait explicitly each iteration. */
+        if (retry_after == DUO_RETRY_AFTER_NONE)
             wait_secs *= backoff_factor;
     }
 }
@@ -437,6 +474,12 @@ duo_call(struct duo_ctx *ctx, const char *method, const char *uri, int msecs)
         _duo_seterr(ctx, "Invalid ikey or skey");
     } else if (code / 100 == 5) {
         /* 5xx indicates an internal server error */
+        ret = DUO_SERVER_ERROR;
+        _duo_seterr(ctx, "HTTP %d", code);
+    } else if (code == 429) {
+        /* Rate-limited past the retry cap: treat as a server-availability
+           failure so the caller applies failmode, rather than a terminal
+           abort. Reaching here means the backoff loop exhausted its retries. */
         ret = DUO_SERVER_ERROR;
         _duo_seterr(ctx, "HTTP %d", code);
     } else {

--- a/lib/https.c
+++ b/lib/https.c
@@ -14,9 +14,12 @@
 #include <sys/socket.h>
 #include <sys/time.h>
 
+#include <errno.h>
+#include <limits.h>
 #include <netdb.h>
 #include <poll.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -97,28 +100,87 @@ __on_body(http_parser *p, const char *buf, size_t len)
     return (BIO_write(req->body, buf, len) != len);
 }
 
+/* Convert a validated relative delay (delta-seconds) to an absolute time_t
+   deadline relative to `now`, or DUO_RETRY_AFTER_INVALID if the value is
+   unusable. Takes `now` as a parameter so the overflow guard is unit-testable
+   without depending on the wall clock. */
+time_t
+_retry_after_deadline(long delay_seconds, int parse_errno, time_t now)
+{
+    /* A day is far larger than any legitimate retry delay for an auth flow.
+       An over-ceiling value is rejected as invalid (not merely capped): the
+       caller treats DUO_RETRY_AFTER_INVALID as terminal, so a hostile server
+       cannot use an implausibly large value to buy extra backoff retries. */
+    const long max_delay_seconds = 86400;
+
+    /* Largest representable time_t. time_t is signed in every environment we
+       target; derive its max from its width so the headroom check holds on
+       32-bit time_t as well as 64-bit. */
+    const time_t time_t_max =
+        (time_t)(((uintmax_t)1 << (sizeof(time_t) * CHAR_BIT - 1)) - 1);
+
+    /* Reject out-of-range (ERANGE from strtol), negative, or implausibly
+       large delays rather than performing an overflowing time_t addition. */
+    if (parse_errno == ERANGE || delay_seconds < 0 ||
+        delay_seconds > max_delay_seconds) {
+        return DUO_RETRY_AFTER_INVALID;
+    }
+    /* Guard the addition itself: even a capped delay can overflow when the
+       clock is near the time_t maximum (e.g. 32-bit time_t approaching
+       2038). Reject rather than wrap. */
+    if (now > time_t_max - (time_t)delay_seconds) {
+        return DUO_RETRY_AFTER_INVALID;
+    }
+    return now + delay_seconds;
+}
+
 time_t
 _parse_retry_after(const char *header_value)
 {
+    /* Only an absent header is "none"; a present-but-unusable header is
+       DUO_RETRY_AFTER_INVALID so the caller does not treat it as license to
+       back off. */
     if (header_value == NULL) {
-        return (time_t)-1;
+        return DUO_RETRY_AFTER_NONE;
     }
 
-    /* Try to parse as an integer (delay in seconds) */
+    /* Try to parse as an integer (delay in seconds). Snapshot errno right
+       after strtol so a later call (e.g. time()) can't clobber it before
+       _retry_after_deadline reads it. */
     char *endptr;
-    long delay_seconds = strtol(header_value, &endptr, 10);
-    if (*endptr == '\0') {
-        return time(NULL) + delay_seconds;
+    long delay_seconds;
+    int strtol_errno;
+
+    errno = 0;
+    delay_seconds = strtol(header_value, &endptr, 10);
+    strtol_errno = errno;
+    if (endptr != header_value && *endptr == '\0') {
+        return _retry_after_deadline(delay_seconds, strtol_errno, time(NULL));
     }
 
-    /* Try to parse as a date */
+    /* Try to parse as an HTTP-date. Use a literal "GMT" rather than %Z:
+       glibc's %Z consumes any token (or none) to the next whitespace/NUL
+       without validating it or applying an offset, so "PST", "XYZ", and an
+       absent zone would all be accepted and treated as GMT. Requiring the
+       literal and then checking for full consumption rejects a bogus or
+       trailing zone. */
     struct tm tm;
     memset(&tm, 0, sizeof(struct tm));
-    if (strptime(header_value, "%a, %d %b %Y %H:%M:%S %Z", &tm) != NULL) {
-        return timegm(&tm);
+    const char *rest = strptime(header_value,
+        "%a, %d %b %Y %H:%M:%S GMT", &tm);
+    if (rest == NULL || *rest != '\0') {
+        return DUO_RETRY_AFTER_INVALID;
     }
 
-    return (time_t)-1;
+    /* Run the parsed date through the same validation as the delta-seconds
+       branch: reject a past or unrepresentable date, and guard the time_t
+       overflow. A past date yields a non-positive delta and is rejected. */
+    time_t now = time(NULL);
+    time_t when = timegm(&tm);
+    if (when == (time_t)-1 || when <= now) {
+        return DUO_RETRY_AFTER_INVALID;
+    }
+    return _retry_after_deadline(when - now, 0, now);
 }
 
 static int

--- a/lib/https.h
+++ b/lib/https.h
@@ -14,6 +14,18 @@
 
 typedef struct https_request https_t;
 
+/* Sentinels for the retry_after value returned by https_recv().
+ *
+ * A Retry-After header has three outcomes, and the caller must treat two of
+ * them differently: an absent header means "no server-directed delay", so the
+ * caller applies its own bounded exponential backoff; a present-but-unusable
+ * header (negative, out of range, past-dated, or malformed) must NOT enable
+ * backoff, because that would let a hostile server buy extra retries and
+ * stall time by sending an implausible value. It is terminal instead, so
+ * failmode is applied at once. A usable header yields an absolute deadline. */
+#define DUO_RETRY_AFTER_NONE    ((time_t)-1)    /* header absent */
+#define DUO_RETRY_AFTER_INVALID ((time_t)-2)    /* header present but unusable */
+
 typedef enum {
     HTTPS_OK,
     HTTPS_ERR_SYSTEM,   /* system problem */

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -376,6 +376,55 @@ class CommonSuites:
             # 1.x seconds + 2.x seconds executed twice
             self.assertGreater(execution_time, 6)
 
+        def test_retry_after_forever_is_bounded(self):
+            """A server that always returns 429 with an in-range Retry-After
+            must not loop forever: the retry cap is reached and failmode is
+            applied instead of hanging. Both failmode=safe (allow, "Failsafe")
+            and failmode=secure (deny, "Failsecure", exit 1) are exercised --
+            this PR changes how the failmode gate is reached for 429s, so the
+            secure half is the security-relevant path to pin."""
+            for config in [MOCKDUO_CONF, MOCKDUO_FAILSECURE]:
+                start_time = time.time()
+                with TempConfig(config) as temp:
+                    result = self.call_binary(
+                        ["-d", "-c", temp.name, "-f", "retry-after-forever", "true"],
+                        timeout=30,
+                    )
+                execution_time = time.time() - start_time
+                self.assertRegexSomeline(
+                    result["stderr"],
+                    r"{prefix} Duo login for 'retry-after-forever'".format(
+                        prefix=config.failmode_as_prefix()
+                    ),
+                )
+                if config.get("failmode") == "secure":
+                    self.assertEqual(result["returncode"], 1)
+                # 6 retries at ~1s each; must terminate well under an
+                # unbounded loop.
+                self.assertLess(execution_time, 20)
+
+        def test_retry_after_negative_is_terminal(self):
+            """A negative Retry-After is present-but-unusable, so it is
+            terminal: the client does not sleep on it (no nanosleep EINVAL
+            spin) and does not treat it as a header-less 429 that would earn
+            the full exponential backoff. It returns at once and applies
+            failmode. A hostile server must not be able to buy stall time or
+            extra requests by sending an invalid value."""
+            start_time = time.time()
+            with TempConfig(MOCKDUO_CONF) as temp:
+                result = self.call_binary(
+                    ["-d", "-c", temp.name, "-f", "retry-after-negative", "true"],
+                    timeout=30,
+                )
+            execution_time = time.time() - start_time
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Failsafe Duo login for 'retry-after-negative'",
+            )
+            # Terminal on the first invalid 429: no backoff, no spin. Must be
+            # far faster than the ~63s the old header-less-backoff path took.
+            self.assertLess(execution_time, 10)
+
     class EscapeInjection(CommonTestCase):
         def run(self, result=None):
             with MockDuo(NORMAL_CERT):

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -347,7 +347,11 @@ class MockDuoHandler(BaseHTTPRequestHandler):
             elif self.args["username"] == "retry-after-date-preauth-allow":
                 if self._rl_req_num == 0:
                     self._rl_req_num = 1
-                    timestr = time.strftime("%a, %d %b %Y %H:%M:%S %Z", time.gmtime(time.time()+3))
+                    # Emit a literal "GMT" zone: the client requires it (a
+                    # permissive %Z is a parser weakness), and %Z on gmtime()
+                    # yields a system-dependent abbreviation (often "UTC" or
+                    # empty) that the strict parser would reject.
+                    timestr = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(time.time()+3))
                     return self._send(429, headers={"Retry-After": timestr})
                 else:
                     self._rl_req_num = 0
@@ -361,6 +365,17 @@ class MockDuoHandler(BaseHTTPRequestHandler):
                     ret["response"] = {"result": "allow", "status_msg": "preauth-allowed"}
                 else:
                     return self._send(500, "Wrong timeout")
+            elif self.args["username"] == "retry-after-forever":
+                # Malicious server: answer EVERY request with 429 and an
+                # in-range Retry-After. The client must still return after a
+                # bounded number of retries so failmode can be applied.
+                # Uses 1s so the bounded retry sequence completes well within
+                # the test harness timeout.
+                return self._send(429, headers={"Retry-After": "1"})
+            elif self.args["username"] == "retry-after-negative":
+                # Malicious server: negative Retry-After. The client must not
+                # spin (nanosleep EINVAL) and must still return, bounded.
+                return self._send(429, headers={"Retry-After": "-100"})
             else:
                 ret["response"] = { "result": "auth" }
                 client_supports_verified_push = bool(

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -263,8 +263,8 @@ class TestMockDuoWithValidCert(CommonSuites.WithValidCert):
 
 
 class TestLoginDuoPreauthStates(CommonSuites.PreauthStates):
-    def call_binary(self, *args):
-        return login_duo(*args)
+    def call_binary(self, *args, **kwargs):
+        return login_duo(*args, **kwargs)
 
 
 class TestLoginDuoEscapeInjection(CommonSuites.EscapeInjection):

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -175,8 +175,8 @@ class TestPamValidCerts(CommonSuites.WithValidCert):
 
 @unittest.skipIf(sys.platform == "sunos5", SOLARIS_ISSUE)
 class TestPamPreauthStates(CommonSuites.PreauthStates):
-    def call_binary(self, *args):
-        return pam_duo(*args)
+    def call_binary(self, *args, **kwargs):
+        return pam_duo(*args, **kwargs)
 
 
 class TestPamEscapeInjection(CommonSuites.EscapeInjection):

--- a/tests/unity_tests/Makefile.am
+++ b/tests/unity_tests/Makefile.am
@@ -12,7 +12,7 @@ TESTS_ENVIRONMENT = env BUILDDIR=$(abs_top_builddir)/unityrunner
 
 SUBDIRS = $(UNITY_VERSION)
 
-UNITY_TESTS = unityrunner add_param_test common_ini_wrong_flag_test common_ini_failmode_test common_ini_prompts_test common_ini_https_timeout common_ini_string_options common_ini_bool_options_test common_ini_min_tls_test common_ini_groups_negation_test add_groupname_test gecos_ini_test duo_log_test https_ipaddr_test sanitize_str_test ga_init_retry_test
+UNITY_TESTS = unityrunner add_param_test common_ini_wrong_flag_test common_ini_failmode_test common_ini_prompts_test common_ini_https_timeout common_ini_string_options common_ini_bool_options_test common_ini_min_tls_test common_ini_groups_negation_test add_groupname_test gecos_ini_test duo_log_test https_ipaddr_test sanitize_str_test ga_init_retry_test parse_retry_after_test
 
 # Create the unity runner executable
 check_PROGRAMS = $(UNITY_TESTS)

--- a/tests/unity_tests/parse_retry_after_test.c
+++ b/tests/unity_tests/parse_retry_after_test.c
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-with-classpath-exception
+ *
+ * parse_retry_after_test.c
+ *
+ * Copyright (c) 2026 Cisco Systems, Inc. and/or its affiliates
+ * All rights reserved.
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <time.h>
+
+#include "src/unity.h"
+#include "https.h"
+
+extern time_t _parse_retry_after(const char *header_value);
+extern time_t _retry_after_deadline(long delay_seconds, int parse_errno, time_t now);
+
+static const time_t TIME_T_MAX =
+    (time_t)(((uintmax_t)1 << (sizeof(time_t) * CHAR_BIT - 1)) - 1);
+
+extern void setUp(void) {};
+extern void tearDown(void) {};
+
+/* A valid small delay returns an absolute time roughly now + delay. */
+static void test_valid_delay_seconds(void)
+{
+    time_t before = time(NULL);
+    time_t result = _parse_retry_after("3");
+    time_t after = time(NULL);
+
+    TEST_ASSERT_TRUE(result >= before + 3);
+    TEST_ASSERT_TRUE(result <= after + 3);
+}
+
+/* An absent header (NULL) yields the "none" sentinel so the caller falls back
+   to its own bounded backoff. This is distinct from a present-but-invalid
+   header, which must be terminal. */
+static void test_null_header(void)
+{
+    TEST_ASSERT_TRUE(_parse_retry_after(NULL) == DUO_RETRY_AFTER_NONE);
+}
+
+/* An empty header string is present-but-unusable, not absent, so it must be
+   the invalid sentinel -- not a deadline of "now" (the pre-guard behavior
+   returned time(NULL)+0). */
+static void test_empty_header(void)
+{
+    TEST_ASSERT_TRUE(_parse_retry_after("") == DUO_RETRY_AFTER_INVALID);
+}
+
+/* Non-numeric, non-date garbage is present-but-unusable: invalid, not none. */
+static void test_garbage(void)
+{
+    TEST_ASSERT_TRUE(_parse_retry_after("not-a-number") == DUO_RETRY_AFTER_INVALID);
+}
+
+/* A negative delay is rejected (invalid), not turned into a past timestamp. */
+static void test_negative_delay(void)
+{
+    TEST_ASSERT_TRUE(_parse_retry_after("-100") == DUO_RETRY_AFTER_INVALID);
+}
+
+/* LONG_MAX would overflow the time_t addition; must be rejected, not computed. */
+static void test_overflow_value(void)
+{
+    TEST_ASSERT_TRUE(
+        _parse_retry_after("9223372036854775807") == DUO_RETRY_AFTER_INVALID);
+}
+
+/* A value past the plausibility ceiling (one day) is rejected as invalid --
+   which the caller treats as terminal, not as a cue to back off. */
+static void test_implausibly_large_delay(void)
+{
+    TEST_ASSERT_TRUE(_parse_retry_after("100000") == DUO_RETRY_AFTER_INVALID);
+}
+
+/* Trailing junk after digits is not a valid delta-seconds value. */
+static void test_trailing_junk(void)
+{
+    TEST_ASSERT_TRUE(_parse_retry_after("30x") == DUO_RETRY_AFTER_INVALID);
+}
+
+/* --- HTTP-date branch --- */
+
+/* A valid future GMT date parses to an absolute deadline near that date. */
+static void test_date_valid_future(void)
+{
+    time_t now = time(NULL);
+    struct tm tm;
+    /* now + 100 seconds, formatted as an HTTP-date in GMT. */
+    time_t target = now + 100;
+    gmtime_r(&target, &tm);
+    char header[64];
+    strftime(header, sizeof(header), "%a, %d %b %Y %H:%M:%S GMT", &tm);
+
+    time_t result = _parse_retry_after(header);
+    /* Allow a second of slack for the clock advancing across the calls. */
+    TEST_ASSERT_TRUE(result >= now + 99);
+    TEST_ASSERT_TRUE(result <= now + 101);
+}
+
+/* A past-dated GMT date is rejected: it yields a non-positive delta. */
+static void test_date_past(void)
+{
+    TEST_ASSERT_TRUE(
+        _parse_retry_after("Thu, 01 Jan 1970 00:00:00 GMT")
+        == DUO_RETRY_AFTER_INVALID);
+}
+
+/* A non-GMT zone must be rejected: the parser requires a literal GMT, so a
+   permissive %Z accepting "PST" as GMT would be a regression. */
+static void test_date_non_gmt_zone(void)
+{
+    TEST_ASSERT_TRUE(
+        _parse_retry_after("Mon, 01 Jan 2035 00:00:00 PST")
+        == DUO_RETRY_AFTER_INVALID);
+}
+
+/* An absent timezone must be rejected -- the literal-GMT requirement fails to
+   match, unlike a permissive %Z which would treat it as GMT. */
+static void test_date_absent_zone(void)
+{
+    TEST_ASSERT_TRUE(
+        _parse_retry_after("Mon, 01 Jan 2035 00:00:00")
+        == DUO_RETRY_AFTER_INVALID);
+}
+
+/* Trailing junk glued to the zone ("GMTjunk") is caught by the
+   full-consumption check even though the literal GMT matched. */
+static void test_date_trailing_glued(void)
+{
+    TEST_ASSERT_TRUE(
+        _parse_retry_after("Mon, 01 Jan 2035 00:00:00 GMTjunk")
+        == DUO_RETRY_AFTER_INVALID);
+}
+
+/* Trailing junk separated by whitespace is likewise rejected by the
+   full-consumption check. */
+static void test_date_trailing_separated(void)
+{
+    TEST_ASSERT_TRUE(
+        _parse_retry_after("Mon, 01 Jan 2035 00:00:00 GMT TRAILING")
+        == DUO_RETRY_AFTER_INVALID);
+}
+
+/* A far-future date must not slip past the ceiling via int narrowing: it is
+   rejected as invalid (over the one-day plausibility ceiling), which the
+   caller treats as terminal. */
+static void test_date_far_future(void)
+{
+    TEST_ASSERT_TRUE(
+        _parse_retry_after("Fri, 31 Dec 9999 23:59:59 GMT")
+        == DUO_RETRY_AFTER_INVALID);
+}
+
+/* --- _retry_after_deadline --- */
+
+/* A normal delay well below time_t_max adds cleanly. */
+static void test_deadline_normal(void)
+{
+    time_t now = 1000;
+    TEST_ASSERT_TRUE(_retry_after_deadline(30, 0, now) == (time_t)1030);
+}
+
+/* ERANGE from strtol is rejected. */
+static void test_deadline_erange(void)
+{
+    TEST_ASSERT_TRUE(
+        _retry_after_deadline(LONG_MAX, ERANGE, 1000) == DUO_RETRY_AFTER_INVALID);
+}
+
+/* A clock within the delay of time_t_max must be rejected rather than allowed
+   to overflow (the 32-bit-2038 case). Compared as time_t directly: a (long)
+   cast here would truncate TIME_T_MAX to -1 on 32-bit long / 64-bit time_t and
+   make the assertion pass vacuously. */
+static void test_deadline_near_time_t_max_overflows(void)
+{
+    time_t now = TIME_T_MAX - 10;   /* only 10s of headroom */
+    TEST_ASSERT_TRUE(
+        _retry_after_deadline(30, 0, now) == DUO_RETRY_AFTER_INVALID);
+}
+
+/* Exactly enough headroom still succeeds. Compared as time_t directly for the
+   same reason as above -- narrowing through (long) would void the test on a
+   64-bit time_t target with 32-bit long. */
+static void test_deadline_exact_headroom(void)
+{
+    time_t now = TIME_T_MAX - 30;
+    TEST_ASSERT_TRUE(_retry_after_deadline(30, 0, now) == TIME_T_MAX);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_valid_delay_seconds);
+    RUN_TEST(test_null_header);
+    RUN_TEST(test_empty_header);
+    RUN_TEST(test_garbage);
+    RUN_TEST(test_negative_delay);
+    RUN_TEST(test_overflow_value);
+    RUN_TEST(test_implausibly_large_delay);
+    RUN_TEST(test_trailing_junk);
+    RUN_TEST(test_date_valid_future);
+    RUN_TEST(test_date_past);
+    RUN_TEST(test_date_non_gmt_zone);
+    RUN_TEST(test_date_absent_zone);
+    RUN_TEST(test_date_trailing_glued);
+    RUN_TEST(test_date_trailing_separated);
+    RUN_TEST(test_date_far_future);
+    RUN_TEST(test_deadline_normal);
+    RUN_TEST(test_deadline_erange);
+    RUN_TEST(test_deadline_near_time_t_max_overflows);
+    RUN_TEST(test_deadline_exact_headroom);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary of the change

Make loop termination independent of a server-supplied Retry-After header, and validate that header consistently across both of its accepted forms (delta-seconds and HTTP-date).

Fixes:
- **lib/duo.c**: cap 429 retries at six (matching the no-header backoff schedule 1,2,4,8,16,32) so `_duo_https_exchange()` always returns and the caller can apply failmode; map a 429 that survives the retry cap to `DUO_SERVER_ERROR` so failmode applies rather than a terminal abort; compute the header-derived delay in `time_t` and clamp it into the backoff band *before* narrowing to `int`, so an out-of-range deadline cannot be masked by the conversion. Only an absent header enables exponential backoff.
- **lib/https.c / lib/https.h**: factor the delay→deadline conversion into `_retry_after_deadline()`, which takes `now` as a parameter so the range and overflow guards are unit-testable; reject out-of-range (ERANGE), negative, and implausibly large values and guard the `time_t` addition against overflow near the `time_t` maximum. Parse the HTTP-date form with a literal `GMT` instead of `%Z` (glibc's `%Z` accepts any token, or none), require full consumption, reject past or unrepresentable dates, and route the result through the same validator as the numeric form. Distinguish "header absent" from "header present but unusable" with two named sentinels (`DUO_RETRY_AFTER_NONE` / `DUO_RETRY_AFTER_INVALID`) so an unusable header does not enable backoff. Snapshot `errno` immediately after `strtol()` rather than reading it as a sibling argument to `time()`.

Tests:
- `parse_retry_after_test` covers **both** branches: numeric (valid / garbage / negative / overflow / over-ceiling / trailing-junk) and HTTP-date (valid-future, past, non-GMT zone, absent zone, trailing junk both glued and whitespace-separated, far-future), plus the empty-header edge case. The near-`time_t` headroom assertions compare `time_t` values directly so a `(long)` truncation on 64-bit-`time_t`/32-bit-`long` targets cannot void them.
- PreauthStates integration tests: a server that replies 429 on every request terminates and applies failmode in bounded time under **both** `failmode=safe` (allow) and `failmode=secure` (deny, exit 1); an unusable header is terminal rather than a full backoff.
- Forward `**kwargs` through the PreauthStates `call_binary` wrappers so tests can set a per-call timeout; the mock date fixture emits a literal GMT zone.

## Review resolution

Addresses the required items from the security review: hardens the HTTP-date branch (item 1); adds HTTP-date and empty-header unit tests (item 2); replaces the overloaded sentinel so an invalid/oversized header is terminal rather than triggering backoff, and corrects the accompanying comment (item 3); covers the fail-secure 429 path in the integration tests (item 4); and compares `time_t` directly so the 2038 assertions are not voided by narrowing (item 5). The remediation approach follows the iteration-cap option; the exponential-doubling alternative was declined so the header-less schedule stays unchanged.

## Test Plan

New and existing tests pass. Verified in a clean build: full unity suite (19 `parse_retry_after` cases + 17 others) green, full `PreauthStates` integration suite green under both failmodes, and cppcheck clean on the changed C files. Each guarded regression was mutation-tested — reverting the date hardening, the terminal-invalid behavior, or the 429→`DUO_SERVER_ERROR` mapping each fails only the corresponding test.

*This PR description update was generated with AI assistance (Claude).*