### PR TITLE
Better handle legacy dev_fips_mode in the config parser

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -176,6 +176,12 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
         cfg->send_gecos = duo_set_boolean_option(val);
     } else if (strcmp(name, "gecos_parsed") == 0) {
         duo_log(LOG_ERR, "The gecos_parsed configuration item for Duo Unix is deprecated and no longer has any effect. Use gecos_delim and gecos_username_pos instead", NULL, NULL, NULL);
+    } else if (strcmp(name, "dev_fips_mode") == 0) {
+        /* Accepted as a no-op for backward compatibility. This option was
+           removed, but rejecting it would abort parsing of the rest of the
+           config file (including any later failmode directive) and could
+           silently disable 2FA on upgrade for configs that still set it. */
+        duo_log(LOG_ERR, "The dev_fips_mode configuration item for Duo Unix is deprecated and no longer has any effect", NULL, NULL, NULL);
     } else if (strcmp(name, "gecos_delim") == 0) {
         if (strlen(val) != 1) {
             fprintf(stderr, "Invalid character option length. Character fields must be 1 character long: '%s'\n", val);

--- a/tests/unity_tests/common_ini_wrong_flag_test.c
+++ b/tests/unity_tests/common_ini_wrong_flag_test.c
@@ -35,10 +35,22 @@ static void test_wrong_flag_null() {
     TEST_ASSERT_FALSE(duo_common_ini_handler(&cfg, SECTION, NULL_STR, value));
 }
 
+/* The removed dev_fips_mode option must be accepted as a no-op (return
+   true) rather than rejected, so a stale key left in a config after
+   upgrade does not abort parsing and silently disable 2FA. */
+static void test_dev_fips_mode_accepted_as_noop() {
+    struct duo_config cfg = {0};
+    char *name = "dev_fips_mode";
+    char *value = "no";
+
+    TEST_ASSERT_TRUE(duo_common_ini_handler(&cfg, SECTION, name, value));
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(test_wrong_flag);
     RUN_TEST(test_wrong_flag_empty);
     RUN_TEST(test_wrong_flag_null);
+    RUN_TEST(test_dev_fips_mode_accepted_as_noop);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary of the change
Accept the removed dev_fips_mode option as a deprecated no-op, matching the existing gecos_parsed handling, so a config still carrying it parses cleanly. Add a unit test covering the no-op acceptance.

## Test Plan
New and existing tests pass
