### PR TITLE
Warn when a groups filter matches no users

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -303,9 +303,15 @@ duo_groups_all_negated(const struct duo_config *cfg)
          * Each stored token is a comma-separated pattern-list, and only
          * the individual patterns can be negated. A single non-negated
          * subpattern (e.g. the "admin" in "!wheel,admin") can still match
-         * a user, so the filter is not all-negated.
+         * a user, so the filter is not all-negated. An empty subpattern
+         * (from a leading, trailing, or doubled comma) matches no group,
+         * so it is skipped rather than treated as a positive match.
          */
         while (*p != '\0') {
+            if (*p == ',') {
+                p++;
+                continue;
+            }
             if (*p != '!') {
                 return 0;
             }

--- a/lib/util.c
+++ b/lib/util.c
@@ -286,6 +286,41 @@ duo_check_groups(struct passwd *pw, char **groups, int groups_cnt)
 }
 
 int
+duo_groups_all_negated(const struct duo_config *cfg)
+{
+    int i;
+
+    if (cfg->groups_cnt <= 0) {
+        return 0;
+    }
+    for (i = 0; i < cfg->groups_cnt; i++) {
+        const char *p = cfg->groups[i];
+
+        if (p == NULL) {
+            return 0;
+        }
+        /*
+         * Each stored token is a comma-separated pattern-list, and only
+         * the individual patterns can be negated. A single non-negated
+         * subpattern (e.g. the "admin" in "!wheel,admin") can still match
+         * a user, so the filter is not all-negated.
+         */
+        while (*p != '\0') {
+            if (*p != '!') {
+                return 0;
+            }
+            while (*p != '\0' && *p != ',') {
+                p++;
+            }
+            if (*p == ',') {
+                p++;
+            }
+        }
+    }
+    return 1;
+}
+
+int
 _add_to_log(char *buf, size_t buf_sz, int pos, const char *format,
            const char *s) {
     if (s == NULL) {

--- a/lib/util.h
+++ b/lib/util.h
@@ -66,6 +66,14 @@ void cleanup_config_groups(struct duo_config *cfg);
 
 int duo_check_groups(struct passwd *pw, char **groups, int groups_cnt);
 
+/*
+ * Return 1 if a groups filter is configured but every pattern is a
+ * negation ('!'-prefixed), meaning the filter can never match any user
+ * and Duo 2FA is effectively disabled host-wide. Returns 0 for an empty
+ * filter or any config containing at least one non-negated pattern.
+ */
+int duo_groups_all_negated(const struct duo_config *cfg);
+
 void duo_log(
     int priority,
     const char *msg,

--- a/login_duo/login_duo.8
+++ b/login_duo/login_duo.8
@@ -139,6 +139,14 @@ For example, to specify Duo authentication for all users (except those
 that are also admins), and for guests:
 .Pp
 .Dl groups = users,!wheel,!*admin guests
+.Pp
+A pattern-list consisting only of negated patterns matches no user, so
+Duo authentication is skipped for everyone. To require authentication for
+all users except a group, include a
+.Sq *
+wildcard, as in
+.Ql groups = *,!wheel .
+A configuration whose patterns are all negated will log a warning.
 .Sh EXAMPLES
 .Nm
 can be enabled system-wide by specifying its full path as a

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -195,6 +195,12 @@ do_auth(struct login_ctx *ctx, const char *cmd)
         return (EXIT_FAILURE);
     }
 
+    if (duo_groups_all_negated(&cfg)) {
+        duo_log(LOG_WARNING, "All configured groups are negated; no user "
+            "can match, so Duo 2FA is disabled for every user (use "
+            "\"*,!group\" to require 2FA for everyone except a group)",
+            NULL, NULL, NULL);
+    }
 
     prompts = cfg.prompts;
 

--- a/pam_duo/pam_duo.8
+++ b/pam_duo/pam_duo.8
@@ -122,6 +122,14 @@ For example, to specify Duo authentication for all users (except those
 that are also admins), and for guests:
 .Pp
 .Dl groups = users,!wheel,!*admin guests
+.Pp
+A pattern-list consisting only of negated patterns matches no user, so
+Duo authentication is skipped for everyone. To require authentication for
+all users except a group, include a
+.Sq *
+wildcard, as in
+.Ql groups = *,!wheel .
+A configuration whose patterns are all negated will log a warning.
 .Sh FILES
 .Bl -tag -width ".Cm failmode"
 .It Pa /etc/duo/pam_duo.conf

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -185,6 +185,13 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
         return (failmode == DUO_FAIL_SAFE ? PAM_SUCCESS : PAM_SERVICE_ERR);
     }
 
+    if (duo_groups_all_negated(&cfg)) {
+        duo_log(LOG_WARNING, "All configured groups are negated; no user "
+            "can match, so Duo 2FA is disabled for every user (use "
+            "\"*,!group\" to require 2FA for everyone except a group)",
+            NULL, NULL, NULL);
+    }
+
     /* Check user */
     if (pam_get_user(pamh, &user, NULL) != PAM_SUCCESS ||
         (pw = getpwnam(user)) == NULL) {

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -67,6 +67,13 @@ class CommonTestCase(unittest.TestCase):
 
         self.assertTrue(found, f"Regex '{regex}' not found in any lines of {result}")
 
+    def assertNotRegexAnyline(self, result: Sequence[str], regex: str):
+        for line in result:
+            self.assertIsNone(
+                re.search(regex, line),
+                f"Regex '{regex}' unexpectedly found in line '{line}'",
+            )
+
     def call_binary(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -291,6 +291,14 @@ MOCKDUO_ADMINS_NO_USERS = DuoUnixConfig(
     group="admin,!users",
 )
 
+MOCKDUO_GROUPS_ALL_NEGATED = DuoUnixConfig(
+    ikey="DIXYZV6YM8IFYVWBINCA",
+    skey="yWHSMhWucAcp7qvuH3HWTaSaKABs8Gaddiv1NIRo",
+    host="localhost:4443",
+    cafile="certs/mockduo-ca.pem",
+    groups="!wheel,!admin",
+)
+
 MOCKDUO_GROUPS_STAR = DuoUnixConfig(
     ikey="DIXYZV6YM8IFYVWBINCA",
     skey="yWHSMhWucAcp7qvuH3HWTaSaKABs8Gaddiv1NIRo",

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -32,6 +32,7 @@ from config import (
     MOCKDUO_GECOS_LONG_DELIM,
     MOCKDUO_GECOS_SEND_UNPARSED,
     MOCKDUO_GECOS_SLASH_DELIM_3_POS,
+    MOCKDUO_GROUPS_ALL_NEGATED,
     MOCKDUO_GROUPS_STAR,
     MOCKDUO_USERS,
     MOCKDUO_USERS_ADMINS,
@@ -571,6 +572,32 @@ class TestLoginDuoGroups(CommonTestCase):
             self.assertRegexSomeline(
                 result["stderr"],
                 r"User preauth-allow bypassed Duo 2FA due to user's UNIX group",
+            )
+
+    def test_all_negated_groups_warns(self):
+        """An all-negated groups filter matches no user and must warn."""
+        with TempConfig(MOCKDUO_GROUPS_ALL_NEGATED) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
+                env={"UID": "1003"},
+                preload_script=os.path.join(TESTDIR, "groups.py"),
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"All configured groups are negated",
+            )
+
+    def test_mixed_groups_does_not_warn(self):
+        """A filter with at least one positive pattern must stay silent."""
+        with TempConfig(MOCKDUO_ADMINS_NO_USERS) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
+                env={"UID": "1003"},
+                preload_script=os.path.join(TESTDIR, "groups.py"),
+            )
+            self.assertNotRegexAnyline(
+                result["stderr"],
+                r"All configured groups are negated",
             )
 
 

--- a/tests/unity_tests/Makefile.am
+++ b/tests/unity_tests/Makefile.am
@@ -12,7 +12,7 @@ TESTS_ENVIRONMENT = env BUILDDIR=$(abs_top_builddir)/unityrunner
 
 SUBDIRS = $(UNITY_VERSION)
 
-UNITY_TESTS = unityrunner add_param_test common_ini_wrong_flag_test common_ini_failmode_test common_ini_prompts_test common_ini_https_timeout common_ini_string_options common_ini_bool_options_test add_groupname_test gecos_ini_test duo_log_test https_ipaddr_test sanitize_str_test ga_init_retry_test
+UNITY_TESTS = unityrunner add_param_test common_ini_wrong_flag_test common_ini_failmode_test common_ini_prompts_test common_ini_https_timeout common_ini_string_options common_ini_bool_options_test common_ini_groups_negation_test add_groupname_test gecos_ini_test duo_log_test https_ipaddr_test sanitize_str_test ga_init_retry_test
 
 # Create the unity runner executable
 check_PROGRAMS = $(UNITY_TESTS)

--- a/tests/unity_tests/common_ini_groups_negation_test.c
+++ b/tests/unity_tests/common_ini_groups_negation_test.c
@@ -87,6 +87,24 @@ static void test_positive_subpattern_in_later_token() {
     TEST_ASSERT_FALSE(duo_groups_all_negated(&cfg));
 }
 
+/* A leading comma yields an empty subpattern that matches nothing; the
+ * filter is still all-negated. */
+static void test_leading_empty_subpattern() {
+    struct duo_config cfg = {0};
+
+    duo_common_ini_handler(&cfg, SECTION, "groups", ",!wheel");
+    TEST_ASSERT_TRUE(duo_groups_all_negated(&cfg));
+}
+
+/* Doubled and trailing commas produce empty subpatterns that match
+ * nothing; the filter is still all-negated. */
+static void test_embedded_empty_subpatterns() {
+    struct duo_config cfg = {0};
+
+    duo_common_ini_handler(&cfg, SECTION, "groups", "!wheel,,!admin,");
+    TEST_ASSERT_TRUE(duo_groups_all_negated(&cfg));
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(test_no_groups);
@@ -98,5 +116,7 @@ int main() {
     RUN_TEST(test_positive_subpattern_after_negation);
     RUN_TEST(test_all_subpatterns_negated);
     RUN_TEST(test_positive_subpattern_in_later_token);
+    RUN_TEST(test_leading_empty_subpattern);
+    RUN_TEST(test_embedded_empty_subpatterns);
     return UNITY_END();
 }

--- a/tests/unity_tests/common_ini_groups_negation_test.c
+++ b/tests/unity_tests/common_ini_groups_negation_test.c
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-with-classpath-exception
+ *
+ * common_ini_groups_negation_test.c
+ *
+ * Copyright (c) 2023 Cisco Systems, Inc. and/or its affiliates
+ * All rights reserved.
+ */
+
+#include "common_ini_test.h"
+
+extern void setUp(void) {};
+extern void tearDown(void) {};
+
+/* An empty groups filter is not "all negated". */
+static void test_no_groups() {
+    struct duo_config cfg = {0};
+
+    TEST_ASSERT_FALSE(duo_groups_all_negated(&cfg));
+}
+
+/* A single negated group can never match any user. */
+static void test_single_negated() {
+    struct duo_config cfg = {0};
+
+    duo_common_ini_handler(&cfg, SECTION, "groups", "!wheel");
+    TEST_ASSERT_TRUE(duo_groups_all_negated(&cfg));
+}
+
+/* Multiple space-separated negations still match no one. */
+static void test_multiple_negated() {
+    struct duo_config cfg = {0};
+
+    duo_common_ini_handler(&cfg, SECTION, "groups", "!wheel !admins");
+    TEST_ASSERT_TRUE(duo_groups_all_negated(&cfg));
+}
+
+/* A single non-negated group is a normal, valid filter. */
+static void test_single_positive() {
+    struct duo_config cfg = {0};
+
+    duo_common_ini_handler(&cfg, SECTION, "groups", "wheel");
+    TEST_ASSERT_FALSE(duo_groups_all_negated(&cfg));
+}
+
+/* The idiomatic "everyone except a group" form must stay silent. */
+static void test_wildcard_then_negated() {
+    struct duo_config cfg = {0};
+
+    duo_common_ini_handler(&cfg, SECTION, "groups", "* !wheel");
+    TEST_ASSERT_FALSE(duo_groups_all_negated(&cfg));
+}
+
+/* A mix of positive and negated patterns is a valid filter. */
+static void test_mixed_positive_and_negated() {
+    struct duo_config cfg = {0};
+
+    duo_common_ini_handler(&cfg, SECTION, "groups", "admins !wheel");
+    TEST_ASSERT_FALSE(duo_groups_all_negated(&cfg));
+}
+
+/*
+ * A comma-separated pattern-list is stored as a single token. A positive
+ * subpattern after an initial negation ("!wheel,admin") can still match,
+ * so it must not be reported as all-negated.
+ */
+static void test_positive_subpattern_after_negation() {
+    struct duo_config cfg = {0};
+
+    duo_common_ini_handler(&cfg, SECTION, "groups", "!wheel,admin");
+    TEST_ASSERT_FALSE(duo_groups_all_negated(&cfg));
+}
+
+/* Every comma-separated subpattern negated still matches no user. */
+static void test_all_subpatterns_negated() {
+    struct duo_config cfg = {0};
+
+    duo_common_ini_handler(&cfg, SECTION, "groups", "!wheel,!admin");
+    TEST_ASSERT_TRUE(duo_groups_all_negated(&cfg));
+}
+
+/* A positive subpattern in a later token also disqualifies the warning. */
+static void test_positive_subpattern_in_later_token() {
+    struct duo_config cfg = {0};
+
+    duo_common_ini_handler(&cfg, SECTION, "groups", "!wheel admin,!staff");
+    TEST_ASSERT_FALSE(duo_groups_all_negated(&cfg));
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_no_groups);
+    RUN_TEST(test_single_negated);
+    RUN_TEST(test_multiple_negated);
+    RUN_TEST(test_single_positive);
+    RUN_TEST(test_wildcard_then_negated);
+    RUN_TEST(test_mixed_positive_and_negated);
+    RUN_TEST(test_positive_subpattern_after_negation);
+    RUN_TEST(test_all_subpatterns_negated);
+    RUN_TEST(test_positive_subpattern_in_later_token);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary of the change
A groups pattern-list made up entirely of negated patterns matches no user, so the filter never selects anyone. Detect this at config load in both login_duo and pam_duo and log a warning, since the more likely intent is to require Duo for everyone except a group ("*,!group").

Adds unit coverage for the subpattern cases and login_duo integration tests for the warn/no-warn paths, plus a note in both man pages' PATTERNS sections.

## Test Plan
New and existing tests pass
