### PR TITLE
Log a warning when TLS certificate verification is disabled

### DIFF
--- a/lib/https.c
+++ b/lib/https.c
@@ -37,6 +37,7 @@
 #include "http_parser.h"
 #include "https.h"
 #include "match.h"
+#include "util.h"
 
 #ifdef HAVE_X509_TEA_SET_STATE
 extern void X509_TEA_set_state(int change);
@@ -728,6 +729,11 @@ https_init(const char *cafile, const char *http_proxy)
         SSL_CTX_set_verify(ctx.ssl_ctx, SSL_VERIFY_PEER, NULL);
     } else if (cafile[0] == '\0') {
         /* Skip verification */
+        duo_log(LOG_WARNING, "TLS certificate verification is disabled "
+            "(noverify is set, or cafile is empty); the connection to Duo is "
+            "encrypted but not authenticated and cannot be trusted. Remove "
+            "noverify and set a valid cafile to restore verification",
+            NULL, NULL, NULL);
         SSL_CTX_set_verify(ctx.ssl_ctx, SSL_VERIFY_NONE, NULL);
     } else {
         /* Load CA cert from file */


### PR DESCRIPTION
## Summary of the change
When the CA file passed to https_init is empty, the Duo server's certificate is not verified. Emit a warning on every authentication in this case so an operator running without verification is made aware and told how to restore it.

## Test Plan
Manually tested

