### PR TITLE
Warn when fallback_local_ip substitutes for a remote client

### DIFF
--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -268,6 +268,12 @@ do_auth(struct login_ctx *ctx, const char *cmd)
             inet_pton(AF_INET6, ip, &addr6) != 1) {
             if (cfg.local_ip_fallback) {
                 host = duo_local_ip();
+                if (ip[0] != '\0') {
+                    duo_log(LOG_WARNING, "fallback_local_ip is replacing the "
+                        "remote client address with this server's IP; the "
+                        "address reported to Duo is not the client's",
+                        NULL, ip, NULL);
+                }
             }
         }
     } else if ((host = ip = (char *)ctx->host) != NULL) {
@@ -275,6 +281,12 @@ do_auth(struct login_ctx *ctx, const char *cmd)
             inet_pton(AF_INET6, ip, &addr6) != 1) {
             if (cfg.local_ip_fallback) {
                 host = duo_local_ip();
+                if (ip[0] != '\0') {
+                    duo_log(LOG_WARNING, "fallback_local_ip is replacing the "
+                        "remote client address with this server's IP; the "
+                        "address reported to Duo is not the client's",
+                        NULL, ip, NULL);
+                }
             }
         }
     }

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -281,6 +281,14 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
         /* Not an IPv4 or IPv6 literal — likely a hostname, check fallback */
         if (cfg.local_ip_fallback) {
             host = duo_local_ip();
+            /* Only a non-empty PAM_RHOST is a real remote client; the empty
+               case is a local (su/sudo) session and must stay silent. */
+            if (ip[0] != '\0') {
+                duo_log(LOG_WARNING, "fallback_local_ip is replacing the "
+                    "remote client address with this server's IP; the "
+                    "address reported to Duo is not the client's",
+                    NULL, ip, NULL);
+            }
         }
     }
 

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -67,6 +67,13 @@ class CommonTestCase(unittest.TestCase):
 
         self.assertTrue(found, f"Regex '{regex}' not found in any lines of {result}")
 
+    def assertNotRegexAnyline(self, result: Sequence[str], regex: str):
+        for line in result:
+            self.assertIsNone(
+                re.search(regex, line),
+                f"Regex '{regex}' unexpectedly found in line '{line}'",
+            )
+
     def call_binary(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -951,6 +951,56 @@ class TestLoginDuoIPv6(CommonTestCase):
                 r"Skipped Duo login for 'preauth-allow' from 1\.2\.3\.4",
             )
 
+    def test_hostname_fallback_warns(self):
+        """Replacing a remote hostname with the server IP must log a warning."""
+        with TempConfig(MOCKDUO_FALLBACK) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
+                env={
+                    "SSH_CONNECTION": "badhost.example.com 50310 server 22",
+                    "FALLBACK": "1",
+                    "UID": "1001",
+                },
+                preload_script=os.path.join(TESTDIR, "login_duo.py"),
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"fallback_local_ip is replacing the remote client address",
+            )
+
+    def test_ip_literal_fallback_does_not_warn(self):
+        """An IPv4 literal is used as-is; no substitution, so no warning."""
+        with TempConfig(MOCKDUO_FALLBACK) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
+                env={
+                    "SSH_CONNECTION": "203.0.113.5 50310 server 22",
+                    "FALLBACK": "1",
+                    "UID": "1001",
+                },
+                preload_script=os.path.join(TESTDIR, "login_duo.py"),
+            )
+            self.assertNotRegexAnyline(
+                result["stderr"],
+                r"fallback_local_ip is replacing the remote client address",
+            )
+
+    def test_local_session_fallback_does_not_warn(self):
+        """A local session (no SSH_CONNECTION) must not emit the remote warning."""
+        with TempConfig(MOCKDUO_FALLBACK) as temp:
+            result = login_duo(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "true"],
+                env={
+                    "FALLBACK": "1",
+                    "UID": "1001",
+                },
+                preload_script=os.path.join(TESTDIR, "login_duo.py"),
+            )
+            self.assertNotRegexAnyline(
+                result["stderr"],
+                r"fallback_local_ip is replacing the remote client address",
+            )
+
 
 class TestLoginDuoMalformedResponse(unittest.TestCase):
     """A server response that fails to parse must not crash the process.


### PR DESCRIPTION
## Summary of the change

With fallback_local_ip enabled, a remote connection whose address is a hostname rather than a numeric literal has that address replaced by the server's own IP, so the value reported to Duo is not the client's. Log a warning in login_duo and pam_duo when this substitution happens for a remote client, while staying silent for local sessions (su/sudo) where no remote address is present.

Adds login_duo integration tests covering the warn and no-warn paths.

## Test Plan
New and existing tests pass; manually tested the pam_duo case.
