### PR TITLE
Add opt-in min_tls config option and TLS-downgrade warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,22 @@ AC_CHECK_HEADERS([inttypes.h limits.h memory.h stdint.h stdlib.h string.h unistd
 
 # Check OpenSSL
 AX_CHECK_OPENSSL([], AC_MSG_FAILURE([OpenSSL not found]))
+# Require at least OpenSSL 1.0.1: the TLS 1.1/1.2 version constants and the
+# min_tls floor and downgrade-warning code depend on it (see README.md).
+AC_MSG_CHECKING([for OpenSSL >= 1.0.1])
+save_CPPFLAGS="$CPPFLAGS"
+CPPFLAGS="$CPPFLAGS $OPENSSL_INCLUDES"
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+        [[#include <openssl/opensslv.h>]],
+        [[
+#if OPENSSL_VERSION_NUMBER < 0x10001000L
+#error "OpenSSL 1.0.1 or later required"
+#endif
+        ]])],
+    [AC_MSG_RESULT([yes])],
+    [AC_MSG_FAILURE([OpenSSL 1.0.1 or later is required for TLS 1.2 support])])
+CPPFLAGS="$save_CPPFLAGS"
 # Define if X509_TEA_set_state exists
 AX_CHECK_X509(AC_DEFINE([HAVE_X509_TEA_SET_STATE],[1],[Define if X509_set_state exists]), [])
 # Default PAM install dir

--- a/lib/duo.c
+++ b/lib/duo.c
@@ -90,7 +90,8 @@ __status_fn(void *arg, const char *msg)
 
 struct duo_ctx *
 duo_open(const char *host, const char *ikey, const char *skey,
-    const char *progname, const char *cafile, int https_timeout, const char* http_proxy)
+    const char *progname, const char *cafile, int https_timeout,
+    const char* http_proxy, int min_tls)
 {
     struct duo_ctx *ctx;
 
@@ -104,7 +105,7 @@ duo_open(const char *host, const char *ikey, const char *skey,
             progname, CANONICAL_HOST, PACKAGE_VERSION) == -1) {
         return (duo_close(ctx));
     }
-    if (https_init(cafile, http_proxy) != HTTPS_OK) {
+    if (https_init(cafile, http_proxy, min_tls) != HTTPS_OK) {
         ctx = duo_close(ctx);
     } else {
         ctx->conv_prompt = __prompt_fn;

--- a/lib/duo.h
+++ b/lib/duo.h
@@ -49,7 +49,8 @@ int duo_parse_config(
     void *arg
 );
 
-/* Open Duo API handle */
+/* Open Duo API handle. min_tls is a DUO_MIN_TLS_* value (0 = library
+ * default, backwards-compatible). */
 duo_t *duo_open(
     const char *host,
     const char *ikey,
@@ -57,7 +58,8 @@ duo_t *duo_open(
     const char *progname,
     const char *cafile,
     int https_timeout,
-    const char *http_proxy
+    const char *http_proxy,
+    int min_tls
 );
 
 /* Override conversation prompt/status functions */

--- a/lib/https.c
+++ b/lib/https.c
@@ -37,6 +37,7 @@
 #include "http_parser.h"
 #include "https.h"
 #include "match.h"
+#include "util.h"
 
 #ifdef HAVE_X509_TEA_SET_STATE
 extern void X509_TEA_set_state(int change);
@@ -677,8 +678,66 @@ HMAC_CTX_free(HMAC_CTX *ctx)
 }
 #endif
 
+/*
+ * Apply the configured minimum TLS version floor to the SSL context.
+ * min_tls is a DUO_MIN_TLS_* value; DUO_MIN_TLS_UNSET leaves the context
+ * untouched so existing deployments keep their current negotiation behavior.
+ * Returns 0 on success, or -1 if the requested floor cannot be enforced by
+ * the linked TLS library (e.g. a 1.3 floor on a library without TLS 1.3).
+ * Callers must fail rather than silently negotiate below the requested floor.
+ */
+static int
+_apply_min_tls(SSL_CTX *ssl_ctx, int min_tls)
+{
+    if (min_tls == DUO_MIN_TLS_UNSET) {
+        return (0);
+    }
+    /* A 1.3 floor requires a TLS 1.3-capable library. Reject it otherwise
+       rather than lowering the floor, which would violate the documented
+       guarantee that connections below the configured version fail. */
+    if (min_tls == DUO_MIN_TLS_1_3) {
+#ifndef TLS1_3_VERSION
+        ctx.errstr = "min_tls 1.3 requires a TLS 1.3-capable library";
+        return (-1);
+#endif
+    }
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+    int version = 0;
+    switch (min_tls) {
+    case DUO_MIN_TLS_1_0: version = TLS1_VERSION; break;
+    case DUO_MIN_TLS_1_1: version = TLS1_1_VERSION; break;
+    case DUO_MIN_TLS_1_2: version = TLS1_2_VERSION; break;
+#ifdef TLS1_3_VERSION
+    case DUO_MIN_TLS_1_3: version = TLS1_3_VERSION; break;
+#endif
+    default: return (-1);
+    }
+    if (!SSL_CTX_set_min_proto_version(ssl_ctx, version)) {
+        ctx.errstr = "failed to set minimum TLS version";
+        return (-1);
+    }
+#else
+    /* Older OpenSSL / LibreSSL lack SSL_CTX_set_min_proto_version; approximate
+       the floor by disabling protocols below it via SSL_CTX_set_options. */
+    long opts = 0;
+    if (min_tls >= DUO_MIN_TLS_1_1) {
+        opts |= SSL_OP_NO_TLSv1;
+    }
+    if (min_tls >= DUO_MIN_TLS_1_2) {
+        opts |= SSL_OP_NO_TLSv1_1;
+    }
+#ifdef SSL_OP_NO_TLSv1_2
+    if (min_tls >= DUO_MIN_TLS_1_3) {
+        opts |= SSL_OP_NO_TLSv1_2;
+    }
+#endif
+    SSL_CTX_set_options(ssl_ctx, opts);
+#endif
+    return (0);
+}
+
 HTTPScode
-https_init(const char *cafile, const char *http_proxy)
+https_init(const char *cafile, const char *http_proxy, int min_tls)
 {
     X509_STORE *store;
     X509 *cert;
@@ -708,6 +767,13 @@ https_init(const char *cafile, const char *http_proxy)
     /* Blacklist SSLv23 */
     const long blacklist = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
     SSL_CTX_set_options(ctx.ssl_ctx, blacklist);
+    /* Apply the opt-in minimum TLS version floor, if configured. Fail rather
+       than negotiate below a floor the library cannot enforce. */
+    if (_apply_min_tls(ctx.ssl_ctx, min_tls) != 0) {
+        SSL_CTX_free(ctx.ssl_ctx);
+        ctx.ssl_ctx = NULL;
+        return (HTTPS_ERR_CLIENT);
+    }
     /* Exclude anonymous and null-encryption ciphers for TLS 1.2 and below.
        Failure is non-fatal: on TLS 1.3-only builds no 1.2 ciphers exist,
        and TLS 1.3 has no aNULL suites. */
@@ -773,6 +839,27 @@ https_init(const char *cafile, const char *http_proxy)
     return (0);
 }
 
+/*
+ * Warn once per connection if the negotiated protocol is older than TLS 1.2.
+ * This fires regardless of the min_tls setting: it is a signal that the Duo
+ * endpoint (or an intermediary) negotiated a deprecated protocol version.
+ */
+static void
+_warn_on_tls_downgrade(SSL *ssl)
+{
+    int version;
+
+    if (ssl == NULL) {
+        return;
+    }
+    version = SSL_version(ssl);
+    if (version < TLS1_2_VERSION) {
+        duo_log(LOG_WARNING, "Negotiated a TLS version older than 1.2 with "
+            "the Duo service; set min_tls to require a newer protocol",
+            NULL, NULL, SSL_get_version(ssl));
+    }
+}
+
 HTTPScode
 https_open(struct https_request **reqp, const char *host, const char *useragent)
 {
@@ -822,6 +909,7 @@ https_open(struct https_request **reqp, const char *host, const char *useragent)
         }
 
         /* SSL already established, skip to the end */
+        _warn_on_tls_downgrade(req->ssl);
         *reqp = req;
         return (HTTPS_OK);
     }
@@ -888,6 +976,7 @@ https_open(struct https_request **reqp, const char *host, const char *useragent)
         https_close(&req);
         return connection_error;
     }
+    _warn_on_tls_downgrade(req->ssl);
     *reqp = req;
 
     return (HTTPS_OK);

--- a/lib/https.h
+++ b/lib/https.h
@@ -22,8 +22,9 @@ typedef enum {
     HTTPS_ERR_SERVER,   /* something the server did */
 } HTTPScode;
 
-/* Initialize HTTPS library */
-HTTPScode https_init(const char *cafile, const char *http_proxy);
+/* Initialize HTTPS library. min_tls is a DUO_MIN_TLS_* value (0 leaves the
+ * negotiated floor at the library default). */
+HTTPScode https_init(const char *cafile, const char *http_proxy, int min_tls);
 
 /* Open HTTPS connection to host[:port] */
 HTTPScode https_open(https_t **hp, const char *host, const char *useragent);

--- a/lib/testduo.c
+++ b/lib/testduo.c
@@ -38,7 +38,7 @@ main(int argc, char *argv[])
                     "DUO_SKEY environment\n");
 		exit(1);
 	}
-	if ((duo = duo_open(host, ikey, skey, "testduo", NULL, DUO_NO_TIMEOUT, NULL)) == NULL) {
+	if ((duo = duo_open(host, ikey, skey, "testduo", NULL, DUO_NO_TIMEOUT, NULL, 0)) == NULL) {
 		fprintf(stderr, "duo_open failed\n");
 		exit(1);
 	}

--- a/lib/util.c
+++ b/lib/util.c
@@ -206,6 +206,22 @@ duo_common_ini_handler(struct duo_config *cfg, const char *section,
         }
     } else if (strcmp(name, "verified_push") == 0) {
         cfg->verified_push = duo_set_boolean_option(val);
+    } else if (strcmp(name, "min_tls") == 0) {
+        /* Opt-in minimum TLS version floor. An empty or unrecognized value
+           leaves the floor unset (current negotiation behavior) rather than
+           selecting the least-safe option. */
+        if (strcmp(val, "1.2") == 0) {
+            cfg->min_tls = DUO_MIN_TLS_1_2;
+        } else if (strcmp(val, "1.3") == 0) {
+            cfg->min_tls = DUO_MIN_TLS_1_3;
+        } else if (strcmp(val, "1.1") == 0) {
+            cfg->min_tls = DUO_MIN_TLS_1_1;
+        } else if (strcmp(val, "1.0") == 0) {
+            cfg->min_tls = DUO_MIN_TLS_1_0;
+        } else {
+            fprintf(stderr, "Invalid min_tls '%s' (expected 1.0, 1.1, 1.2, or 1.3)\n", val);
+            return (0);
+        }
     } else {
         /* Couldn't handle the option, maybe it's target specific? */
         return (0);

--- a/lib/util.h
+++ b/lib/util.h
@@ -24,6 +24,21 @@ enum {
     DUO_FAIL_SECURE
 };
 
+/*
+ * Configured minimum TLS version floor. DUO_MIN_TLS_UNSET (0, the default
+ * after duo_config_default()) leaves the library's negotiation behavior
+ * unchanged for backwards compatibility. The library maps the remaining
+ * values to OpenSSL protocol-version constants when initializing the
+ * SSL context.
+ */
+enum {
+    DUO_MIN_TLS_UNSET = 0,
+    DUO_MIN_TLS_1_0,
+    DUO_MIN_TLS_1_1,
+    DUO_MIN_TLS_1_2,
+    DUO_MIN_TLS_1_3
+};
+
 struct duo_config {
     char *ikey;
     char *skey;
@@ -46,6 +61,7 @@ struct duo_config {
     int  send_gecos;
     int  gecos_username_pos;
     int  verified_push;
+    int  min_tls;   /* Minimum TLS version floor: DUO_MIN_TLS_* */
 };
 
 void duo_config_default(struct duo_config *cfg);

--- a/login_duo/login_duo.8
+++ b/login_duo/login_duo.8
@@ -103,6 +103,18 @@ If unable to determine the authentication users's IP address, fallback on the
 IP address of the server. Default is "no".
 .It Cm https_timeout
 Set to the number of seconds to wait for HTTPS responses from Duo Security. If Duo Security takes longer than the configured number of seconds to respond to the preauth API call, the configured failmode is triggered. Other network operations such as DNS resolution, TCP connection establishment, and the SSL handshake have their own independent timeout and retry logic. Default is 0, which disables the HTTPS timeout.
+.It Cm min_tls
+Require at least the given TLS protocol version when connecting to Duo.
+Accepts
+.Dq Li 1.0 ,
+.Dq Li 1.1 ,
+.Dq Li 1.2 ,
+or
+.Dq Li 1.3 .
+Connections that cannot negotiate at least this version will fail. When
+unset, the system default negotiation is used. Setting
+.Dq Li 1.2
+or higher is recommended.
 .El
 .Pp
 An example configuration file:

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -283,7 +283,7 @@ do_auth(struct login_ctx *ctx, const char *cmd)
     if ((duo = duo_open(cfg.apihost, cfg.ikey, cfg.skey,
                     "login_duo/" PACKAGE_VERSION,
                     cfg.noverify ? "" : cfg.cafile,
-                    cfg.https_timeout, cfg.http_proxy)) == NULL) {
+                    cfg.https_timeout, cfg.http_proxy, cfg.min_tls)) == NULL) {
         duo_log(LOG_ERR, "Couldn't open Duo API handle",
             pw->pw_name, host, NULL);
         close_config(&cfg);

--- a/pam_duo/pam_duo.8
+++ b/pam_duo/pam_duo.8
@@ -87,6 +87,18 @@ edited by the end user.  If you must enable it, first restrict
 (for example by setting
 .Cm CHFN_RESTRICT
 to deny the fields used, or by removing its setuid bit).
+.It Cm min_tls
+Require at least the given TLS protocol version when connecting to Duo.
+Accepts
+.Dq Li 1.0 ,
+.Dq Li 1.1 ,
+.Dq Li 1.2 ,
+or
+.Dq Li 1.3 .
+Connections that cannot negotiate at least this version will fail. When
+unset, the system default negotiation is used. Setting
+.Dq Li 1.2
+or higher is recommended.
 .El
 .Pp
 An example configuration file:

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -287,7 +287,8 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
     /* Try Duo auth */
     if ((duo = duo_open(cfg.apihost, cfg.ikey, cfg.skey,
                     "pam_duo/" PACKAGE_VERSION,
-                    cfg.noverify ? "" : cfg.cafile, cfg.https_timeout, cfg.http_proxy)) == NULL) {
+                    cfg.noverify ? "" : cfg.cafile, cfg.https_timeout, cfg.http_proxy,
+                    cfg.min_tls)) == NULL) {
         duo_log(LOG_ERR, "Couldn't open Duo API handle", pw->pw_name, host, NULL);
         close_config(&cfg);
         return (PAM_SERVICE_ERR);

--- a/tests/common_suites.py
+++ b/tests/common_suites.py
@@ -67,6 +67,13 @@ class CommonTestCase(unittest.TestCase):
 
         self.assertTrue(found, f"Regex '{regex}' not found in any lines of {result}")
 
+    def assertNotRegexAnyline(self, result: Sequence[str], regex: str):
+        for line in result:
+            self.assertIsNone(
+                re.search(regex, line),
+                f"Regex '{regex}' unexpectedly found in line '{line}'",
+            )
+
     def call_binary(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/tests/mockduo.py
+++ b/tests/mockduo.py
@@ -432,10 +432,19 @@ class MockDuoHandler(BaseHTTPRequestHandler):
 class HTTPServerV6(HTTPServer):
     address_family = socket.AF_INET6
 
+TLS_VERSIONS = {
+    "1.0": ssl.TLSVersion.TLSv1,
+    "1.1": ssl.TLSVersion.TLSv1_1,
+    "1.2": ssl.TLSVersion.TLSv1_2,
+    "1.3": ssl.TLSVersion.TLSv1_3,
+}
+
+
 def main():
     port = 4443
     host = "::"
     anull = False
+    max_tls = None
 
     args = sys.argv[1:]
     if "--anull" in args:
@@ -444,6 +453,13 @@ def main():
     if "--malformed" in args:
         MockDuoHandler._malformed = True
         args.remove("--malformed")
+    # Cap the highest TLS version the mock server will negotiate, e.g.
+    # "--max-tls=1.2", to exercise the client's min_tls floor and its
+    # downgrade warning.
+    for arg in list(args):
+        if arg.startswith("--max-tls="):
+            max_tls = arg.split("=", 1)[1]
+            args.remove(arg)
 
     if len(args) == 0:
         cafile = os.path.realpath(
@@ -452,7 +468,7 @@ def main():
     elif len(args) == 1:
         cafile = args[0]
     else:
-        print("Usage: {0} [--anull] [--malformed] [certfile]\n".format(sys.argv[0]), file=sys.stderr)
+        print("Usage: {0} [--anull] [--malformed] [--max-tls=VERSION] [certfile]\n".format(sys.argv[0]), file=sys.stderr)
         sys.exit(1)
 
     httpd = HTTPServerV6((host, port), MockDuoHandler)
@@ -463,6 +479,15 @@ def main():
         ctx.maximum_version = ssl.TLSVersion.TLSv1_2
     else:
         ctx.load_cert_chain(cafile)
+    if max_tls is not None:
+        if max_tls not in TLS_VERSIONS:
+            print("Invalid --max-tls value: {0}\n".format(max_tls), file=sys.stderr)
+            sys.exit(1)
+        # Lowering the ceiling below TLS 1.2 requires relaxing the OpenSSL
+        # security level so the deprecated protocol/ciphers remain available.
+        if TLS_VERSIONS[max_tls] < ssl.TLSVersion.TLSv1_2:
+            ctx.set_ciphers("DEFAULT@SECLEVEL=0")
+        ctx.maximum_version = TLS_VERSIONS[max_tls]
     httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
 
     httpd.serve_forever()

--- a/tests/mockduo_context.py
+++ b/tests/mockduo_context.py
@@ -70,11 +70,13 @@ class MockDuoTimeoutException(MockDuoException):
 
 
 class MockDuo:
-    def __init__(self, cert=NORMAL_CERT, anull=False, malformed=False):
+    def __init__(self, cert=NORMAL_CERT, anull=False, malformed=False, max_tls=None):
         self.cert = cert
         self.cmd = ["python3", os.path.join(TESTDIR, "mockduo.py")]
         if malformed:
             self.cmd.append("--malformed")
+        if max_tls is not None:
+            self.cmd.append("--max-tls={0}".format(max_tls))
         if anull:
             self.cmd.append("--anull")
         else:

--- a/tests/test_login_duo.py
+++ b/tests/test_login_duo.py
@@ -216,6 +216,46 @@ class TestLoginDuoAnonCipher(CommonTestCase):
             )
 
 
+class TestLoginDuoMinTLS(CommonTestCase):
+    """The min_tls floor must reject a server that cannot meet it, and must
+    allow a server that can. The mock server is capped at TLS 1.2."""
+
+    def run(self, result=None):
+        with MockDuo(max_tls="1.2"):
+            return super(TestLoginDuoMinTLS, self).run(result)
+
+    def _config(self, **extra):
+        return DuoUnixConfig(
+            ikey="DIXYZV6YM8IFYVWBINCA",
+            skey="yWHSMhWucAcp7qvuH3HWTaSaKABs8Gaddiv1NIRo",
+            host="localhost:4443",
+            cafile="certs/mockduo-ca.pem",
+            failmode="secure",
+            **extra,
+        )
+
+    def test_min_tls_1_3_rejects_1_2_server(self):
+        """min_tls=1.3 against a TLS 1.2 server must fail the handshake."""
+        with TempConfig(self._config(min_tls="1.3")) as temp:
+            result = login_duo(["-d", "-c", temp.name, "-f", "preauth-allow", "true"])
+            self.assertEqual(result["returncode"], 1)
+            self.assertRegexSomeline(result["stderr"], r"Couldn't connect to")
+
+    def test_min_tls_1_2_allows_1_2_server(self):
+        """min_tls=1.2 against a TLS 1.2 server must connect and authenticate."""
+        with TempConfig(self._config(min_tls="1.2")) as temp:
+            result = login_duo(["-d", "-c", temp.name, "-f", "preauth-allow", "true"])
+            self.assertRegexSomeline(result["stderr"], r"preauth-allowed")
+            self.assertNotRegexAnyline(result["stderr"], r"Couldn't connect to")
+
+    def test_min_tls_unset_allows_1_2_server(self):
+        """An unset min_tls must preserve the existing permissive behavior."""
+        with TempConfig(self._config()) as temp:
+            result = login_duo(["-d", "-c", temp.name, "-f", "preauth-allow", "true"])
+            self.assertRegexSomeline(result["stderr"], r"preauth-allowed")
+            self.assertNotRegexAnyline(result["stderr"], r"Couldn't connect to")
+
+
 class TestMockDuoWithValidCert(CommonSuites.WithValidCert):
     def call_binary(self, *args):
         return login_duo(*args)

--- a/tests/unity_tests/Makefile.am
+++ b/tests/unity_tests/Makefile.am
@@ -12,7 +12,7 @@ TESTS_ENVIRONMENT = env BUILDDIR=$(abs_top_builddir)/unityrunner
 
 SUBDIRS = $(UNITY_VERSION)
 
-UNITY_TESTS = unityrunner add_param_test common_ini_wrong_flag_test common_ini_failmode_test common_ini_prompts_test common_ini_https_timeout common_ini_string_options common_ini_bool_options_test add_groupname_test gecos_ini_test duo_log_test https_ipaddr_test sanitize_str_test ga_init_retry_test
+UNITY_TESTS = unityrunner add_param_test common_ini_wrong_flag_test common_ini_failmode_test common_ini_prompts_test common_ini_https_timeout common_ini_string_options common_ini_bool_options_test common_ini_min_tls_test add_groupname_test gecos_ini_test duo_log_test https_ipaddr_test sanitize_str_test ga_init_retry_test
 
 # Create the unity runner executable
 check_PROGRAMS = $(UNITY_TESTS)

--- a/tests/unity_tests/common_ini_min_tls_test.c
+++ b/tests/unity_tests/common_ini_min_tls_test.c
@@ -1,0 +1,86 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-with-classpath-exception
+ *
+ * common_ini_min_tls_test.c
+ *
+ * Copyright (c) 2023 Cisco Systems, Inc. and/or its affiliates
+ * All rights reserved.
+ */
+
+#include "common_ini_test.h"
+
+extern void setUp(void) {};
+extern void tearDown(void) {};
+
+/* Each accepted value maps to the matching DUO_MIN_TLS_* constant. */
+static void test_min_tls_1_0() {
+    struct duo_config cfg = {0};
+
+    TEST_ASSERT_TRUE(duo_common_ini_handler(&cfg, SECTION, "min_tls", "1.0"));
+    TEST_ASSERT_EQUAL(DUO_MIN_TLS_1_0, cfg.min_tls);
+}
+
+static void test_min_tls_1_1() {
+    struct duo_config cfg = {0};
+
+    TEST_ASSERT_TRUE(duo_common_ini_handler(&cfg, SECTION, "min_tls", "1.1"));
+    TEST_ASSERT_EQUAL(DUO_MIN_TLS_1_1, cfg.min_tls);
+}
+
+static void test_min_tls_1_2() {
+    struct duo_config cfg = {0};
+
+    TEST_ASSERT_TRUE(duo_common_ini_handler(&cfg, SECTION, "min_tls", "1.2"));
+    TEST_ASSERT_EQUAL(DUO_MIN_TLS_1_2, cfg.min_tls);
+}
+
+static void test_min_tls_1_3() {
+    struct duo_config cfg = {0};
+
+    TEST_ASSERT_TRUE(duo_common_ini_handler(&cfg, SECTION, "min_tls", "1.3"));
+    TEST_ASSERT_EQUAL(DUO_MIN_TLS_1_3, cfg.min_tls);
+}
+
+/* The default (unset) value leaves the floor at DUO_MIN_TLS_UNSET. */
+static void test_min_tls_default_unset() {
+    struct duo_config cfg = {0};
+
+    duo_config_default(&cfg);
+    TEST_ASSERT_EQUAL(DUO_MIN_TLS_UNSET, cfg.min_tls);
+}
+
+/* Invalid values are rejected and must not select any floor. */
+static void test_min_tls_invalid_junk() {
+    struct duo_config cfg = {0};
+
+    TEST_ASSERT_FALSE(duo_common_ini_handler(&cfg, SECTION, "min_tls", "junk"));
+    TEST_ASSERT_EQUAL(DUO_MIN_TLS_UNSET, cfg.min_tls);
+}
+
+static void test_min_tls_invalid_version() {
+    struct duo_config cfg = {0};
+
+    TEST_ASSERT_FALSE(duo_common_ini_handler(&cfg, SECTION, "min_tls", "9.9"));
+    TEST_ASSERT_EQUAL(DUO_MIN_TLS_UNSET, cfg.min_tls);
+}
+
+/* An empty value must not silently pick the least-safe floor. */
+static void test_min_tls_empty() {
+    struct duo_config cfg = {0};
+
+    TEST_ASSERT_FALSE(duo_common_ini_handler(&cfg, SECTION, "min_tls", EMPTY_STR));
+    TEST_ASSERT_EQUAL(DUO_MIN_TLS_UNSET, cfg.min_tls);
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_min_tls_1_0);
+    RUN_TEST(test_min_tls_1_1);
+    RUN_TEST(test_min_tls_1_2);
+    RUN_TEST(test_min_tls_1_3);
+    RUN_TEST(test_min_tls_default_unset);
+    RUN_TEST(test_min_tls_invalid_junk);
+    RUN_TEST(test_min_tls_invalid_version);
+    RUN_TEST(test_min_tls_empty);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary of the change

Add a new min_tls configuration key (accepting 1.0, 1.1, 1.2, or 1.3) that sets a minimum TLS protocol version floor for connections to the Duo service. When unset, negotiation is unchanged, so existing deployments are unaffected.

Independently of min_tls, log a warning when a connection negotiates a protocol older than TLS 1.2, naming the negotiated version.

Document the option in both man pages and cover parsing with a new Unity test plus login_duo integration tests using a TLS-capped mockduo.

## Test Plan
New and existing tests pass
