### PR TITLE
pam_duo: warn when client address is a hostname, not an IP

### DIFF
--- a/pam_duo/pam_duo.8
+++ b/pam_duo/pam_duo.8
@@ -156,7 +156,22 @@ When used with OpenSSH's
 .Xr sshd 8 ,
 only PAM-based authentication can be protected with this module;
 pubkey authentication bypasses PAM entirely. OpenSSH's PAM
-integration also does not honor an interactive 
+integration also does not honor an interactive
 .Xr pam_conv 3
 conversation, prohibiting real-time Duo status messages (such as
 during voice callback).
+.Pp
+Set
+.Cm UseDNS no
+in
+.Xr sshd_config 5
+so that
+.Nm
+receives the client's IP address rather than a resolved hostname. Duo
+network policies (Authorized Networks allow/deny lists) match on IP
+address; when
+.Cm UseDNS
+is enabled the client address arrives as a hostname, which no IP-based
+policy can match, and
+.Nm
+logs a warning to that effect.

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -297,11 +297,13 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
                     NULL, ip, NULL);
             }
         } else if (ip[0] != '\0') {
-            /* PAM_RHOST is a hostname, not an IP; it is still sent as-is but
-               Duo network policies match on IP, so they will not apply. */
-            duo_log(LOG_WARNING, "Client address is a hostname, not an IP; "
-                "Duo network policies will not match this login (set "
-                "\"UseDNS no\" in sshd_config so the client IP is passed)",
+            /* PAM_RHOST is not an IP literal (typically a resolved hostname);
+               it is still sent as-is but Duo network policies match on IP, so
+               they will not apply. */
+            duo_log(LOG_WARNING, "Client address is not a valid IP address; "
+                "Duo network policies will not match this login (if this is "
+                "sshd, set \"UseDNS no\" in sshd_config so the client IP is "
+                "passed)",
                 NULL, ip, NULL);
         }
     }

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -296,6 +296,13 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
                     "address reported to Duo is not the client's",
                     NULL, ip, NULL);
             }
+        } else if (ip[0] != '\0') {
+            /* PAM_RHOST is a hostname, not an IP; it is still sent as-is but
+               Duo network policies match on IP, so they will not apply. */
+            duo_log(LOG_WARNING, "Client address is a hostname, not an IP; "
+                "Duo network policies will not match this login (set "
+                "\"UseDNS no\" in sshd_config so the client IP is passed)",
+                NULL, ip, NULL);
         }
     }
 

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -189,6 +189,30 @@ class TestPamHosts(CommonSuites.Hosts):
     def call_binary(self, *args, **kwargs):
         return pam_duo(timeout=15, *args, **kwargs)
 
+    HOSTNAME_WARNING = r"Client address is a hostname, not an IP"
+
+    def test_hostname_client_warns(self):
+        """A non-IP PAM_RHOST is still sent, but logs the policy warning."""
+        with TempConfig(MOCKDUO_CONF) as temp:
+            result = self.call_binary(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "-h", "nowhere", "true"]
+            )
+            self.assertRegexSomeline(result["stderr"], self.HOSTNAME_WARNING)
+            # The hostname is still reported as the client address (no
+            # behavior change; only a warning is added).
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"Skipped Duo login for 'preauth-allow' from nowhere: preauth-allowed",
+            )
+
+    def test_ip_client_does_not_warn(self):
+        """A valid IP literal must not trigger the hostname warning."""
+        with TempConfig(MOCKDUO_CONF) as temp:
+            result = self.call_binary(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "-h", "1.2.3.4", "true"]
+            )
+            self.assertNotRegexAnyline(result["stderr"], self.HOSTNAME_WARNING)
+
 
 @unittest.skipIf(sys.platform == "sunos5", SOLARIS_ISSUE)
 class TestPamHTTPProxy(CommonSuites.HTTPProxy):

--- a/tests/test_pam_duo.py
+++ b/tests/test_pam_duo.py
@@ -189,7 +189,7 @@ class TestPamHosts(CommonSuites.Hosts):
     def call_binary(self, *args, **kwargs):
         return pam_duo(timeout=15, *args, **kwargs)
 
-    HOSTNAME_WARNING = r"Client address is a hostname, not an IP"
+    HOSTNAME_WARNING = r"Client address is not a valid IP address"
 
     def test_hostname_client_warns(self):
         """A non-IP PAM_RHOST is still sent, but logs the policy warning."""
@@ -206,10 +206,53 @@ class TestPamHosts(CommonSuites.Hosts):
             )
 
     def test_ip_client_does_not_warn(self):
-        """A valid IP literal must not trigger the hostname warning."""
+        """A valid IPv4 literal must not trigger the hostname warning."""
         with TempConfig(MOCKDUO_CONF) as temp:
             result = self.call_binary(
                 ["-d", "-c", temp.name, "-f", "preauth-allow", "-h", "1.2.3.4", "true"]
+            )
+            self.assertNotRegexAnyline(result["stderr"], self.HOSTNAME_WARNING)
+
+    def test_ipv6_client_does_not_warn(self):
+        """A valid IPv6 literal must not trigger the hostname warning.
+
+        Guards the inet_pton(AF_INET6, ...) half of the condition, which is
+        the only thing preventing a spurious warning on every IPv6 client.
+        """
+        with TempConfig(MOCKDUO_CONF) as temp:
+            result = self.call_binary(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "-h", "::1", "true"]
+            )
+            self.assertNotRegexAnyline(result["stderr"], self.HOSTNAME_WARNING)
+
+    def test_local_session_does_not_warn(self):
+        """A local session (empty PAM_RHOST, no -h) must stay silent.
+
+        Guards the `ip[0] != '\\0'` check: without it, every local su/sudo
+        session (empty PAM_RHOST -> ip = "") would fail both literal checks
+        and emit a spurious warning.
+        """
+        with TempConfig(MOCKDUO_CONF) as temp:
+            result = self.call_binary(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "true"]
+            )
+            self.assertNotRegexAnyline(result["stderr"], self.HOSTNAME_WARNING)
+
+    def test_hostname_with_fallback_warns_once(self):
+        """With fallback_local_ip on, only the fallback warning fires.
+
+        Guards the `else if`: downgrading it to a plain `if` would emit both
+        the fallback-substitution warning and the hostname warning for the
+        same login.
+        """
+        with TempConfig(MOCKDUO_FALLBACK) as temp:
+            result = self.call_binary(
+                ["-d", "-c", temp.name, "-f", "preauth-allow", "-h", "nowhere", "true"],
+                env={"FALLBACK": "1"},
+            )
+            self.assertRegexSomeline(
+                result["stderr"],
+                r"fallback_local_ip is replacing the remote client address",
             )
             self.assertNotRegexAnyline(result["stderr"], self.HOSTNAME_WARNING)
 


### PR DESCRIPTION
## Summary of the change

When PAM_RHOST is a resolved hostname (or any non-IP-literal value) rather than an IP literal — for example under "UseDNS yes" in sshd — pam_duo still sends it as the client address, but Duo network policies match on IP and cannot apply. Log a warning to that effect and document the guidance in the man page.

**Scope: this is an interim, warn-only mitigation. The client-side send behavior is intentionally unchanged — the address is still sent as-is.** Changing what is sent (omitting a non-IP value, or routing it through fallback_local_ip) would break existing hostname-based deployments and is tracked separately as a deliberate behavior change; the complementary server-side fail-closed hardening is also tracked separately. This PR does not close that work.

## Changes

- pam_duo warns once per authentication attempt when the client address is not a valid IP literal.
- Warning text is "Client address is not a valid IP address" (it also covers malformed IP literals, not only hostnames), and the "UseDNS no" remediation hint is scoped to sshd since pam_duo also serves sudo, su, and arbitrary PAM stacks.
- Man-page guidance added.

## Test Plan

New and existing tests pass. Coverage pins each branch condition:
- hostname / non-IP client -> warns; the address is still reported unchanged.
- IPv4 literal -> no warning.
- IPv6 literal (`-h ::1`) -> no warning (guards the `inet_pton(AF_INET6)` arm).
- Local session (empty PAM_RHOST) -> no warning (guards the `ip[0]` check).
- With fallback_local_ip on -> only the fallback warning fires, not both (guards the `else if`).

Both guards were mutation-verified: downgrading the `else if` to a plain `if` fails the fallback test, and dropping the `ip[0]` guard fails the local-session test.

*This update was generated with AI assistance (Claude).*
