### PR TITLE
docs: note the test suite requires Python 3.7 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,18 @@ You should only see "Hello World" if the authentication succeeds.
 
 ## Running the tests
 
-The additional prereq for running the tests is python
+The additional prereq for running the tests is Python 3.7 or higher. (The
+test harness uses features added in Python 3.7; note this is a test-only
+requirement, `login_duo` and `pam_duo` themselves have no Python dependency.)
 ```
 #  RHEL Based
-$ sudo yum install python
+$ sudo yum install python3
 #  Debian Based
-$ sudo apt-get install python
+$ sudo apt-get install python3
 ```
+On distributions whose default `python3` is older than 3.7 (for example
+RHEL/Rocky 8, which ships Python 3.6), install a newer interpreter and make
+sure `python3` on your `PATH` resolves to it before running the tests.
 
 To run all the automated tests simply run
 ```
@@ -101,17 +106,17 @@ $ sudo make check
 To run an individual test file
 ```
 $ cd tests/
-$ python test_login_duo.py
+$ python3 test_login_duo.py
 ```
 To run an individual test suite
 ```
 $ cd tests/
-$ python test_login_duo.py TestLoginDuoConfig
+$ python3 test_login_duo.py TestLoginDuoConfig
 ```
 To run an individual test case
 ```
 $ cd tests/
-$ python test_login_duo.py TestLoginDuoConfig.test_empty_args
+$ python3 test_login_duo.py TestLoginDuoConfig.test_empty_args
 ```
 
 ### Python Tests
@@ -144,7 +149,7 @@ Each test creates the mockduo server for you, but if you need to run it manually
 Below is an example of running a mockduo server in one session and authenticating against it in another.
 ```
 $ cd tests/
-$ python mockduo.py certs/mockduo.pem
+$ python3 mockduo.py certs/mockduo.pem
 Now in a separate terminal window
 $ ../login_duo/login_duo -d -c confs/mockduo.conf -f my_username echo "Success"
 ```


### PR DESCRIPTION
## Summary of the change

The Python test harness uses `ssl.TLSVersion`, added in Python 3.7, to build
the mock Duo server's TLS-version table. On distributions whose default
`python3` is older — notably RHEL/Rocky 8, which ships Python 3.6 — `mockduo.py`
raises `AttributeError: module 'ssl' has no attribute 'TLSVersion'` on import,
so the mock server never starts and `make check` fails.

This is a **test-only** requirement: `login_duo` and `pam_duo` are C and have no
Python dependency (the `min_tls` feature uses OpenSSL's
`SSL_CTX_set_min_proto_version`, present on Rocky 8's OpenSSL 1.1.1). Only the
test harness needs the newer interpreter.

Update the README "Running the tests" section to:

- State that the test suite requires Python 3.7 or higher, and that this is
  test-only.
- Note that on distributions whose default `python3` is older than 3.7 (e.g.
  Rocky 8), `python3` on `PATH` must resolve to a newer interpreter before
  running the tests.
- Correct the stale `yum install python` (which installs Python 2 on RHEL) and
  the bare `python` invocations to `python3`.

## Test Plan

Documentation only; no code change.

*This PR description was generated with AI assistance (Claude).*
