### PR TITLE
Add min_tls to the support-script conf allowlist

### DIFF
--- a/duo_unix_support/duo_unix_support.sh
+++ b/duo_unix_support/duo_unix_support.sh
@@ -149,7 +149,7 @@ scrub_duo_conf () {
     ( umask 077 && : > "$dst" ) || return 1
     if ! awk '
         BEGIN {
-            split("ikey host cafile http_proxy groups group failmode pushinfo noverify prompts autopush accept_env_factor fallback_local_ip https_timeout send_gecos gecos_parsed gecos_delim gecos_username_pos verified_push motd", a, " ")
+            split("ikey host cafile http_proxy groups group failmode pushinfo noverify prompts autopush accept_env_factor fallback_local_ip https_timeout send_gecos gecos_parsed gecos_delim gecos_username_pos verified_push min_tls motd", a, " ")
             for (i in a) allow[a[i]] = 1
             dropped = 0
         }

--- a/duo_unix_support/test_scrub_duo_conf.sh
+++ b/duo_unix_support/test_scrub_duo_conf.sh
@@ -204,6 +204,15 @@ CONF
 )" '' \
    '^groups = admins #devops$'
 
+assert_scrub min_tls_preserved "$(cat <<'CONF'
+[duo]
+ikey = DIABC
+min_tls = 1.2
+CONF
+)" '' \
+   '^ikey = DIABC$' \
+   '^min_tls = 1\.2$'
+
 assert_scrub skey_in_comment_dropped "$(cat <<'CONF'
 # backup skey: 4MjRQ2NmRiM2Q1Y
 [duo]


### PR DESCRIPTION
## Summary

The `min_tls` config option was added to the parser and both man pages, but never added to the allowlist used by the support-bundle conf scrubber in `duo_unix_support/duo_unix_support.sh`. As a result a `min_tls` line in `pam_duo.conf` / `login_duo.conf` is **silently redacted** from a collected support bundle and counted in the "N option(s) were dropped" tally.

`min_tls` is non-sensitive (values are `1.0`/`1.1`/`1.2`/`1.3`) and is exactly the kind of TLS-diagnostic option support would want visible — the allowlist already includes comparable diagnostics like `noverify`, `cafile`, and `https_timeout`.

## Changes

- Add `min_tls` to the allowlist `split(...)` string in `scrub_duo_conf`.
- Add a `min_tls_preserved` regression test to `test_scrub_duo_conf.sh` asserting a `min_tls = 1.2` line survives scrubbing.

## Testing

- `test_scrub_duo_conf.sh`: 19/19 pass (was 18, + the new case).
- Mutation-checked: reverting the allowlist addition makes `min_tls_preserved` fail, confirming the test guards the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)