### PR TITLE
Fix support-script conf scrubber on legacy awk implementations

### DIFF
--- a/duo_unix_support/duo_unix_support.sh
+++ b/duo_unix_support/duo_unix_support.sh
@@ -164,8 +164,22 @@ scrub_duo_conf () {
                 }
                 prev = c
             }
-            sub(/[[:space:]]+$/, "", v)
+            sub(/[ \t\r]+$/, "", v)
             return v
+        }
+        # True for a bare "[section]" line, matching lib/ini.c semantics.
+        function is_section_header(v,    t, inner) {
+            t = v
+            sub(/^[ \t\r]+/, "", t)
+            sub(/[ \t\r]+$/, "", t)
+            if (length(t) < 2) {
+                return 0
+            }
+            if (substr(t, 1, 1) != "[" || substr(t, length(t), 1) != "]") {
+                return 0
+            }
+            inner = substr(t, 2, length(t) - 2)
+            return index(inner, "]") == 0
         }
         # Replace userinfo in http_proxy with "REDACTED@", keeping the host.
         function redact_userinfo(v,    lower, scheme_len, scheme, rest, i, c, auth_end, last_at) {
@@ -212,11 +226,11 @@ scrub_duo_conf () {
         }
         {
             line = $0
-            if (line ~ /^[[:space:]]*$/) {
+            if (line ~ /^[ \t\r]*$/) {
                 print line
                 next
             }
-            if (line ~ /^[[:space:]]*[#;]/) {
+            if (line ~ /^[ \t\r]*[#;]/) {
                 if (tolower(line) ~ /skey/) {
                     dropped++
                     next
@@ -224,23 +238,23 @@ scrub_duo_conf () {
                 print line
                 next
             }
-            if (line ~ /^[[:space:]]*\[[^]]*\][[:space:]]*$/) {
+            if (is_section_header(line)) {
                 print line
                 next
             }
-            if (match(line, /^[[:space:]]*[A-Za-z_][A-Za-z0-9._-]*[[:space:]]*=/) == 0) {
+            if (match(line, /^[ \t\r]*[A-Za-z_][A-Za-z0-9._-]*[ \t\r]*=/) == 0) {
                 next
             }
             eq = index(line, "=")
             name = substr(line, 1, eq - 1)
-            sub(/^[[:space:]]+/, "", name)
-            sub(/[[:space:]]+$/, "", name)
+            sub(/^[ \t\r]+/, "", name)
+            sub(/[ \t\r]+$/, "", name)
             if (!(name in allow)) {
                 dropped++
                 next
             }
             value = substr(line, eq + 1)
-            sub(/^[[:space:]]+/, "", value)
+            sub(/^[ \t\r]+/, "", value)
             value = strip_inline_comment(value)
             if (name == "http_proxy") {
                 value = redact_userinfo(value)

--- a/duo_unix_support/test_scrub_duo_conf.sh
+++ b/duo_unix_support/test_scrub_duo_conf.sh
@@ -15,16 +15,29 @@ if [ ! -f "${COLLECTOR}" ]; then
     exit 2
 fi
 
+# Solaris /usr/bin/grep has no -E and /usr/bin/awk is the legacy nawk, which
+# does not support POSIX bracket expressions.  Prefer the GNU tools when present.
+if type ggrep >/dev/null 2>&1; then
+    GREP=ggrep
+else
+    GREP=grep
+fi
+if type gawk >/dev/null 2>&1; then
+    AWK=gawk
+else
+    AWK=awk
+fi
+
 FN_TMP="$(mktemp)"
 trap 'rm -f "${FN_TMP}"' EXIT
 
-awk '
+"${AWK}" '
     /^scrub_duo_conf \(\) \{$/ { in_fn = 1 }
     in_fn { print }
     in_fn && /^\}$/ { exit }
 ' "${COLLECTOR}" > "${FN_TMP}"
 
-if ! grep -q '^scrub_duo_conf ()' "${FN_TMP}"; then
+if ! "${GREP}" -q '^scrub_duo_conf ()' "${FN_TMP}"; then
     echo "failed to extract scrub_duo_conf from ${COLLECTOR}" >&2
     exit 2
 fi
@@ -62,7 +75,7 @@ assert_scrub () {
         return
     fi
 
-    if [ -n "${forbidden}" ] && grep -qE "${forbidden}" "${dst}"; then
+    if [ -n "${forbidden}" ] && "${GREP}" -qE "${forbidden}" "${dst}"; then
         printf 'FAIL %s: forbidden regex %q matched in output:\n' "${name}" "${forbidden}" >&2
         sed 's/^/    /' "${dst}" >&2
         FAIL=$((FAIL + 1))
@@ -70,7 +83,7 @@ assert_scrub () {
     fi
 
     while [ "$#" -gt 0 ]; do
-        if ! grep -qE "$1" "${dst}"; then
+        if ! "${GREP}" -qE "$1" "${dst}"; then
             printf 'FAIL %s: expected regex %q not found in output:\n' "${name}" "$1" >&2
             sed 's/^/    /' "${dst}" >&2
             FAIL=$((FAIL + 1))
@@ -137,6 +150,19 @@ CONF
 )" '4MjRQ2NmRiM2Q1Y|PW|skey backup|internal notes' \
    '^ikey = DIXXXX$' \
    '^host = api-example\.com$'
+
+assert_scrub section_header_preserved "$(cat <<'CONF'
+[duo]
+ikey = DIABC
+CONF
+)" '' \
+   '^\[duo\]$' \
+   '^ikey = DIABC$'
+
+assert_scrub section_header_indented "$(printf '  [duo]  \nikey = DIABC\n')" \
+   '' \
+   '^  \[duo\]  $' \
+   '^ikey = DIABC$'
 
 assert_scrub section_header_junk "$(cat <<'CONF'
 [duo] skey = INSIDE_SECTION_HEADER


### PR DESCRIPTION
## Summary of the change

`scrub_duo_conf` produced a **zero-byte** scrubbed config on Solaris while
returning success, so support bundles from Solaris hosts contained no
configuration data — with no error shown to the user or in the bundle.

Found during pre-release manual testing on Solaris 11.4 SPARC. This code is
new since 2.2.3, so it is not a regression from a released version; it has
never worked on Solaris.

There were two independent incompatibilities with the original one-true-awk
regex engine. The second was masked by the first.

### 1. POSIX character classes

On Solaris, `/usr/bin/awk` is `nawk`, which parses `[[:space:]]` as the set
`[:space` plus a literal `]`. The key/value guard therefore never matched a
real config line, every line hit `next`, and the output file stayed empty.
The function's exit status was unaffected, hence the silent failure.

```
$ echo 'ikey = DIABC' | /usr/bin/nawk '{ print (match($0, /^[[:space:]]*[A-Za-z_][A-Za-z0-9._-]*[[:space:]]*=/) == 0) ? "NO MATCH" : "MATCH" }'
NO MATCH
```

### 2. Negated bracket expression

The section-header test used `[^]]`, whose first member is a literal `]`.
POSIX treats that `]` as literal; nawk does not. A bare `[duo]` line was
silently dropped. This only became visible after fixing (1), since no line
previously reached that branch — output was 242 bytes instead of 248, the
missing 6 being exactly `[duo]\n`.

## Changes

- Replace all 8 `[[:space:]]` occurrences with `[ \t\r]`.
- Replace the section-header regex with an `is_section_header()` helper built
  from `substr`/`index`. Escaping as `[^\]]` also works on nawk, but relies on
  backslash being special *inside* a bracket expression, which POSIX leaves
  undefined — and mawk is the default awk on Debian/Ubuntu. `length`/`substr`/
  `index` are core awk with no dialect variance.
- Add `section_header_preserved` and `section_header_indented` tests. The
  existing `section_header_junk` case only asserted that a *malformed* header
  is dropped, so the suite passed while clean headers were vanishing.
- Prefer `ggrep`/`gawk` in the test harness when present; Solaris
  `/usr/bin/grep` has no `-E`, which made failures hard to read.

The collector still calls bare `awk`, deliberately. Interpreter detection was
considered and rejected: `gawk` is not guaranteed on a minimal Solaris install,
so detection could still fall through to nawk and silently reproduce the
zero-byte output. A dialect-agnostic program fixes it unconditionally, and a
missing awk now fails loudly rather than shipping an empty conf.

`[ \t\r]` is narrower than `lib/ini.c`'s `isspace()`, which also covers
vertical tab and form feed. A VT/FF-prefixed option line is now dropped rather
than emitted — the safe direction, and not a realistic Duo conf.

## Test Plan

`duo_unix_support/test_scrub_duo_conf.sh` — 21 tests (19 existing + 2 new).

| awk | Result |
| --- | --- |
| Solaris 11.4 nawk (hardware) | 21/21; scrubber output 248 bytes, header present |
| AIX system awk (hardware) | correct output, byte-identical to BSD awk |
| gawk 5.1 (Rocky 9 / AlmaLinux 9) | 21/21 |
| gawk 4.2.1 (openSUSE Leap 15) | 21/21 |
| gawk, mawk, original-awk (Debian 12) | 21/21 each |
| Ubuntu 22.04 default | 21/21 |
| BSD awk (macOS) | 21/21 |

`original-awk` is the same lineage as Solaris nawk and AIX awk.

Also verified:

- Scrubber output is **byte-identical to the previous implementation on GNU
  awk** across a conf exercising bare/indented/junk headers, `;` and `#`
  comments, blank lines, inline `#` in `groups`, proxy userinfo with a query
  string, hyphenated names, and both drop paths.
- Old regex vs new helper: 0 divergences over a 29-line adversarial corpus
  (`[]`, `[a][b]`, `[[duo]]`, `[a]b]`, `[]]`, bare `[`, CRLF).
- `make dist` succeeds and the extracted tarball copy passes 21/21.
- Full collector end-to-end: correct scrubbed conf, no secret leaked,
  tarball mode 600.
- No leak with `skey` prefixed by any `isspace()` character in three
  positions, plus `SKEY`/`Skey`/quoted/continuation variants.
